### PR TITLE
Feature/delete orphans

### DIFF
--- a/Automation/psi_digitalocean_apiv2.py
+++ b/Automation/psi_digitalocean_apiv2.py
@@ -347,6 +347,14 @@ def get_servers(digitalocean_account):
 
     return [(str(droplet.id), droplet.name) for droplet in droplets if droplet.tags == []]
 
+def get_server(digitalocean_account, droplet_id):
+    try:
+        do_mgr = digitalocean.Manager(token=digitalocean_account.oauth_token)
+        droplet = do_mgr.get_droplet(droplet_id)
+        return droplet
+    except Exception as e:
+        raise e
+
 def remove_server(digitalocean_account, droplet_id):
     """
         Destroys a digitalocean droplet.

--- a/Automation/psi_linode_api4.py
+++ b/Automation/psi_linode_api4.py
@@ -282,6 +282,11 @@ def get_servers(linode_account):
     linodes = linode_api.list_linodes()
     return [(str(li.id), li.label) for li in linodes if not li.tags]
 
+def get_server(linode_account, linode_id):
+    linode_api = PsiLinode(linode_account)
+    linode =linode_api.linode_list(linode_id)
+    return linode
+
 def remove_server(linode_account, linode_id):
     linode_api = PsiLinode(linode_account)
     try:

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -2549,6 +2549,7 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
             sys.stderr.write(provider + ' orphans:\n' + str(orphans) + '\n\n')
 
     def delete_orphans(self, provider, hosts_provider_id_list):
+        pending_deletion = []
         provider_controller = globals()["psi_{}".format(provider)]
         provider_account = vars(self)["_PsiphonNetwork__{}_account".format(provider)]
 
@@ -2574,10 +2575,19 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                                   )
             user_response = raw_input("Do you want to delete this orphan host? ")
             if user_response in ['yes', 'y', 'Y', 'Yes']:
-                print('Deleting the host: {}'.format(host_name))
-                provider_controller.remove_server(provider_account, host_provider_id) # method delete server through API
+                print('Adding host to deletion list - the host: {}'.format(host_name))
+                pending_deletion.append(orphan.id)
+                #provider_controller.remove_server(provider_account, host_provider_id) # method delete server through API
             else:
                 print("Do Nothing")
+
+        user_confirm = raw_input('Start deleting following orphan hosts: \n{}\nDo you want to procee? '.format(pending_deletion))
+        if user_confirm in ['yes', 'y', 'Y', 'Yes']:
+            for i in pending_deletion:
+                print("Deleting: {}".format(i))
+                proddvider_controller.remove_server(provider_account, i) # method delete server through API
+        else:
+            print("Abort the delete orphans job.")
 
 
     def __copy_date_range(self, date_range):

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -2565,12 +2565,12 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                   Tags:                    %s
                   ''') % (
                                 str(orphan.id),
-                                orphan.name if provider=='digitalocean' else orphan.label,
-                                orphan.status,
-                                orphan.created_at if provider=='digitalocean' else orphan.created.strftime('%Y-%m-%dT%H:%M:%S'),
-                                orphan.networks['v4'][0]['ip_address'] if provider=='digitalocean' else orphan.ipv4[0],
-                                orphan.region['slug'] if provider=='digitalocean' else orphan.region.id,
-                                str(orphan.tags)
+                                orphan.name if provider=='digitalocean' or provider=='vpsnet' else orphan.label,
+                                orphan.state if provider=='vpsnet' else orphan.status,
+                                orphan.created_at if provider=='digitalocean' else orphan.public_ips[0]['ip_address']['created_at'] if provider=='vpsnet' else orphan.created.strftime('%Y-%m-%dT%H:%M:%S'),
+                                orphan.networks['v4'][0]['ip_address'] if provider=='digitalocean' else orphan.public_ips[0]['ip_address']['ip_address'] if provider=='vpsnet' else orphan.ipv4[0],
+                                orphan.region['slug'] if provider=='digitalocean' else orphan.region.id if provider=='linode' else 'No Region infomation',
+                                str(orphan.tags) if provider!='vpsnet' else 'VPS.net node has no tags'
                                   )
             user_response = raw_input("Do you want to delete this orphan host? ")
             if user_response in ['yes', 'y', 'Y', 'Yes']:

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -2581,11 +2581,11 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
             else:
                 print("Do Nothing")
 
-        user_confirm = raw_input('Start deleting following orphan hosts: \n{}\nDo you want to procee? '.format(pending_deletion))
+        user_confirm = raw_input('Start deleting following orphan hosts: \n{}\nDo you want to process? '.format(pending_deletion))
         if user_confirm in ['yes', 'y', 'Y', 'Yes']:
             for i in pending_deletion:
                 print("Deleting: {}".format(i))
-                proddvider_controller.remove_server(provider_account, i) # method delete server through API
+                provider_controller.remove_server(provider_account, i) # method delete server through API
         else:
             print("Abort the delete orphans job.")
 

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -2548,6 +2548,15 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
             orphans = self.list_orphans(provider)
             sys.stderr.write(provider + ' orphans:\n' + str(orphans) + '\n\n')
 
+    def delete_orphans(self, provider, hosts_provider_id_list):
+        provider_controller = globals()["psi_()".format(provider)]
+        provider_account = vars(self)["_PsiphonNetwork__()_account".format(provider)]
+
+        for host_provider_id in hosts_provider_id_list:
+            # TODO: safety check to avoid delete production servers
+            provider_controller.remove_server(provider_account, host_provider_id) # method delete server through API
+
+
     def __copy_date_range(self, date_range):
         return (datetime.datetime(date_range[0].year,
                                   date_range[0].month,


### PR DESCRIPTION
This PR update one feature in Linode and DigitalOcean providers API helper function file which get host's information from API and return for information print

The main change is adding the delete orphans function in psi_ops.py which:
- Print orphan's information based on API 
- Prompt user input to select wether delete orphan or do nothing
- delete orphan through API if user input is `['yes', 'y', 'Y', 'Yes']` (means for agree to delete)

