### PR TITLE
Fix auto-update cron job

### DIFF
--- a/EmailResponder/FeedbackDecryptor/FeedbackDecryptorCron
+++ b/EmailResponder/FeedbackDecryptor/FeedbackDecryptorCron
@@ -20,4 +20,4 @@
 
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-0 * * * *   ubuntu    cd /opt/psiphon/psiphon-automation/EmailResponder/FeedbackDecryptor && /bin/bash cronjob.sh
+0 * * * *   maildecryptor    cd /opt/psiphon/psiphon-automation/EmailResponder/FeedbackDecryptor && /bin/bash cronjob.sh

--- a/EmailResponder/FeedbackDecryptor/cronjob.sh
+++ b/EmailResponder/FeedbackDecryptor/cronjob.sh
@@ -21,7 +21,7 @@ git pull
 
 # Update the local copy of psinet
 cd ../../Automation
-python ./psi_update_stats_dat.py
+python2 psi_update_stats_dat.py
 cd -
 
 # Restart services to use the new code and psinet

--- a/EmailResponder/FeedbackDecryptor/install.sh
+++ b/EmailResponder/FeedbackDecryptor/install.sh
@@ -48,7 +48,7 @@ rm *.service.configured
 sudo chmod 0400 *.pem conf.json
 sudo chown $MAILDECRYPTOR_USER:$MAILDECRYPTOR_USER *.pem conf.json
 
-sudo cp FeedbackDecryptor.cron /etc/cron.d
+sudo cp FeedbackDecryptorCron /etc/cron.d
 
 sudo systemctl stop s3decryptor
 sudo systemctl stop mailsender


### PR DESCRIPTION
Files in /etc/cron.d are ignored if there's a `.` in the name.

Also, the cron job should be executed as the maildecryptor user.