### PR TITLE
Use SES Signature Version 4 via boto3

### DIFF
--- a/EmailResponder/FeedbackDecryptor/sender.py
+++ b/EmailResponder/FeedbackDecryptor/sender.py
@@ -111,6 +111,6 @@ def send_response(recipient, from_address,
         return
 
     try:
-        sendmail.send_raw_email_amazonses(raw_email, from_address)
+        sendmail.send_raw_email_amazonses(raw_email, from_address, recipient)
     except:
         raise

--- a/EmailResponder/README.md
+++ b/EmailResponder/README.md
@@ -37,7 +37,7 @@ We could probably use Postfix's [virtual mailbox](http://www.postfix.org/VIRTUAL
     ```
     sudo apt-get update
     sudo apt-get upgrade
-    sudo apt-get install mercurial python-pip libwww-perl libdatetime-perl rsyslog-gnutls
+    sudo apt-get install mercurial python-pip libwww-perl libdatetime-perl rsyslog-gnutls awscli
     sudo reboot
     ```
 
@@ -319,17 +319,19 @@ Optional, but if logwatch is not present then the stats processing code will nee
 
 ### Amazon AWS services
 
+We're slowly transitioning from boto (v2) to boto3 and currently use both.
+
 1. Install boto
 
    ```
-   sudo pip install --upgrade boto
+   sudo pip install --upgrade boto boto3
    ```
 
 2. It's best if the AWS user being used is created through the AWS IAM
    interface and has only the necessary privileges. See the appendix for
    permission policies.
 
-3. Put AWS credentials into boto config file. Info here:
+3. Put AWS credentials into boto2 config file. Info here:
    <http://code.google.com/p/boto/wiki/BotoConfig>
 
    We've found that using `~/.boto` doesn't work, so create `/etc/boto.cfg` and
@@ -343,6 +345,19 @@ Optional, but if logwatch is not present then the stats processing code will nee
 
    Ensure that the file is readable by the `mail_responder` user.
 
+4. Use the standard AWS credential store for boto3 (as the `mail_responder` user).
+
+```
+$ aws configure
+
+AWS Access Key ID [None]: <key ID>
+AWS Secret Access Key [None]: <secret key>
+Default region name [None]: us-east-1
+Default output format [None]:
+
+$ sudo cp -R ~/.aws /home/mail_responder
+$ sudo chown mail_responder:mail_responder /home/mail_responder/.aws
+```
 
 ### Source files and cron jobs
 

--- a/EmailResponder/mail_process.py
+++ b/EmailResponder/mail_process.py
@@ -162,7 +162,8 @@ class MailResponder(object):
                 # If sending via SES, we'll use its DKIM facility -- so don't do it here.
                 try:
                     if not sendmail.send_raw_email_amazonses(raw_response,
-                                                             self._response_from_addr):
+                                                             self._response_from_addr,
+                                                             self._requester_addr):
                         return False
                 except BotoServerError as ex:
                     if ex.error_message == 'Address blacklisted.':

--- a/EmailResponder/settings.py
+++ b/EmailResponder/settings.py
@@ -70,9 +70,10 @@ ADMIN_FORWARD_ADDRESSES = ['mick@example.com', 'keith@example.com']
 # Will appear at the start of subject of administrative email sent by this server
 ADMIN_FORWARD_SUBJECT_TAG = '[MailResponder]'
 
-
 # This must match the local send service specified in /etc/postfix/master.cf
 LOCAL_SMTP_SEND_PORT = 2525
+
+AWS_SES_REGION = 'us-east-1'
 
 
 #


### PR DESCRIPTION
AWS has deprecated SES Signature Version 4 for API requests, and it will stop working September 30, 2020.

Boto2 seems to not support v4 (https://stackoverflow.com/a/63454370/729729), so we need to switch to boto3. The two boto versions can coexist, so this isn't a complete switch from one to the other -- only where necessary.