### PR TITLE
Put Scaleway P_ID to database

### DIFF
--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -319,6 +319,7 @@ VPS247Account = psi_utils.recordtype(
 ScalewayAccount = psi_utils.recordtype(
     'ScalewayAccount',
     'api_token, regions, base_ssh_port, ' +
+    'organization_id, project_id, ' +
     'base_rsa_private_key',
     default=None)
 
@@ -864,6 +865,10 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                 host.enable_gquic = True
                 host.limit_quic_versions = None
             self.version = '0.68'
+        if cmp(parse_version(self.version), parse_version('0.69')) < 0:
+            self.__scaleway_account.organization_id = ''
+            self.__scaleway_account.project_id = ''
+            self.version = '0.69'
 
     def initialize_plugins(self):
         for plugin in plugins:

--- a/Automation/psi_scaleway.py
+++ b/Automation/psi_scaleway.py
@@ -70,7 +70,7 @@ class PsiScaleway:
         self.api_token = scaleway_account.api_token
         self.region = random.choice(scaleway_account.regions)
         self.client = ScalewayApis.ComputeAPI(auth_token=self.api_token, region=self.region)
-        self.project_id = ScalewayApis.AccountAPI(auth_token=self.api_token).query().tokens(self.api_token).get()['token']['project_id']
+        self.project_id = scaleway_account.project_id
 
     def reload(self):
         self.client = ScalewayApis.ComputeAPI(auth_token=self.api_token, region=self.region)


### PR DESCRIPTION
Scaleway API Changes:

Scaleway API is upgraded to V2 and their Python SDK is upgraded as well. Looks like they stop using the AccountAPI endpoint at `https://account.scaleway.com`

In order to quick fix the issue that PsiScaleway unable to get `project_id` (Throw 404 error when calling through HTTP). We put the project ID hardcoded in the database.