### PR TITLE
Optional ciphershare password prompt

### DIFF
--- a/Automation/.gitignore
+++ b/Automation/.gitignore
@@ -9,3 +9,5 @@ network-health/
 *ssl*
 deploy.py
 psinet.py
+*.exe
+*.dll

--- a/Automation/.gitignore
+++ b/Automation/.gitignore
@@ -9,5 +9,3 @@ network-health/
 *ssl*
 deploy.py
 psinet.py
-*.exe
-*.dll

--- a/Automation/psi_ops_cms.py
+++ b/Automation/psi_ops_cms.py
@@ -89,10 +89,10 @@ def lock_document():
 def export_document(dest_filename):
     if sys.platform in ['win32','cygwin']:
         cmd = 'CipherShareScriptingClient.exe'
-      # os.remove(dest_filename) is not necessary on windows OS as it will overwrite the psi_ops.db file.
+        # os.remove(dest_filename) is not necessary on windows OS as it will overwrite the psi_ops.db file.
     else:
         cmd = 'wine CipherShareScriptingClient.exe'
-     #  For Linux CS client will create error due to existing file path. so removing previous file (psi_ops.db from relative location $PSI_OPS_DB_FILENAME) is necesary. 
+        # For Linux CS client will create error due to existing file path. so removing previous file (psi_ops.db from relative location $PSI_OPS_DB_FILENAME) is necesary.
         os.remove(dest_filename)
     cmd += ' ExportDocument \
             -UserName %s -Password %s \

--- a/Automation/psi_ops_cms.py
+++ b/Automation/psi_ops_cms.py
@@ -29,7 +29,7 @@ import getpass
 
 
 PSI_OPS_ROOT = os.path.abspath(os.path.join('..', 'Data', 'PsiOps'))
-PSI_OPS_DB_FILENAME = os.path.join(PSI_OPS_ROOT, 'psi_ops_devops.dat')
+PSI_OPS_DB_FILENAME = os.path.join(PSI_OPS_ROOT, 'psi_ops.dat')
 
 
 if os.path.isfile('psi_data_config.py'):
@@ -81,7 +81,7 @@ def lock_document():
 
     proc = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = proc.communicate()
-    
+
     if proc.returncode != 0:
         raise Exception('CipherShare lock failed: ' + str(output))
 
@@ -109,7 +109,7 @@ def export_document(dest_filename):
     print("Exporting Document...")
     proc = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = proc.communicate()
-    
+
     if proc.returncode != 0:
         raise Exception('CipherShare export failed: ' + str(output))
 
@@ -141,10 +141,10 @@ def import_document(source_filename, for_stats=False, for_devops=False):
                 psi_ops_config.CIPHERSHARE_SHAREGROUP,
             psi_ops_config.CIPHERSHARE_PSI_OPS_DOCUMENT_DESCRIPTION,
             '' if for_stats or for_devops else '-KeepLocked')
-    
+
     proc = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = proc.communicate()
-    
+
     if proc.returncode != 0:
         raise Exception('CipherShare import failed: ' + str(output))
 
@@ -163,10 +163,10 @@ def delete_document(for_stats=False):
             psi_ops_config.CIPHERSHARE_SERVERPORT,
             psi_ops_config.CIPHERSHARE_PSI_OPS_FOR_STATS_DOCUMENT_PATH if for_stats else
                 psi_ops_config.CIPHERSHARE_PSI_OPS_FOR_DEVOPS_DOCUMENT_PATH)
-    
+
     proc = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = proc.communicate()
-    
+
     if proc.returncode != 0:
         raise Exception('CipherShare delete failed: ' + str(output))
 
@@ -234,7 +234,7 @@ class PersistentObject(object):
         return obj
 
     def upgrade(self):
-        pass 
+        pass
 
     def initialize_plugins(self):
         pass

--- a/Automation/psi_ops_cms.py
+++ b/Automation/psi_ops_cms.py
@@ -89,8 +89,10 @@ def lock_document():
 def export_document(dest_filename):
     if sys.platform in ['win32','cygwin']:
         cmd = 'CipherShareScriptingClient.exe'
+      # os.remove(dest_filename) is not necessary on windows OS as it will overwrite the psi_ops.db file.
     else:
         cmd = 'wine CipherShareScriptingClient.exe'
+     #  For Linux CS client will create error due to existing file path. so removing previous file (psi_ops.db from relative location $PSI_OPS_DB_FILENAME) is necesary. 
         os.remove(dest_filename)
     cmd += ' ExportDocument \
             -UserName %s -Password %s \

--- a/Automation/psi_ops_cms.py
+++ b/Automation/psi_ops_cms.py
@@ -92,7 +92,7 @@ def export_document(dest_filename):
         # os.remove(dest_filename) is not necessary on windows OS as it will overwrite the psi_ops.db file.
     else:
         cmd = 'wine CipherShareScriptingClient.exe'
-        # For Linux CS client will create error due to existing file path. so removing previous file (psi_ops.db from relative location $PSI_OPS_DB_FILENAME) is necesary.
+        # For Linux CS client will create error due to existing file path. so removing previous file (psi_ops.db from relative location $PSI_OPS_DB_FILENAME) is necessary.
         os.remove(dest_filename)
     cmd += ' ExportDocument \
             -UserName %s -Password %s \

--- a/Automation/requirements.txt
+++ b/Automation/requirements.txt
@@ -8,7 +8,7 @@ linode_api4==2.2.1
 paramiko==2.11.0
 Pillow==6.2.2 
 python-digitalocean==1.15.0
-pywin32==304
+#pywin32==304
 pyyaml==5.3.1 
 qrcode==6.1
 slumber==0.7.1

--- a/Automation/requirements.txt
+++ b/Automation/requirements.txt
@@ -8,7 +8,6 @@ linode_api4==2.2.1
 paramiko==2.11.0
 Pillow==6.2.2 
 python-digitalocean==1.15.0
-#pywin32==304
 pyyaml==5.3.1 
 qrcode==6.1
 slumber==0.7.1


### PR DESCRIPTION
Currently, it will only prompt for passwords while exporting documents from Ciphershare and not for other tasks like locking, deleting, etc. but this will be updated later once it is tested. 

This commit also has an updated OS info check for running Ciphershare as it runs differently on windows and Linux systems.
(See export document section on lines 89-95)

