### PR TITLE
Disable OCI API's HTTP debug output

### DIFF
--- a/Automation/psi_oci.py
+++ b/Automation/psi_oci.py
@@ -62,7 +62,7 @@ def wait_while_condition(condition, max_wait_seconds, description):
 #
 ###
 class PsiOCI:
-    def __init__(self, oracle_account):
+    def __init__(self, oracle_account, debug=False):
         self.config = {
             "user": oracle_account.oci_user,
             "key_content": oracle_account.oci_user_ssh_key,
@@ -70,7 +70,7 @@ class PsiOCI:
             "tenancy": oracle_account.oci_tenancy_id,
             "compartment": oracle_account.oci_compartment_id,
             "region": random.choice(oracle_account.regions),
-            "log_requests": True
+            "log_requests": debug
         }
 
         self.image_source_uri=oracle_account.oci_bucket_image_url


### PR DESCRIPTION
Add debug option for OCI class
and set the default value to False which disabled the HTTP output