### PR TITLE
Feature/psinet reload

### DIFF
--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -5016,7 +5016,7 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
         super(PsiphonNetwork, self).save()
 
     def reload(self):
-        print 'reloading...'
+        print('reloading...')
         super(PsiphonNetwork, self).load(self.is_locked)
 
 

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -5015,6 +5015,10 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
         print 'saving...'
         super(PsiphonNetwork, self).save()
 
+    def reload(self):
+        print 'reloading...'
+        super(PsiphonNetwork, self).load(self.is_locked)
+
 
 def unit_test():
     psinet = PsiphonNetwork()


### PR DESCRIPTION
This will add a `psinet.reload()` function which can reload (Export the latest database) psinet without exit the python shell. Tested working with latest python3 on Debian 12. 