### PR TITLE
Add IPMI information to psinet Host object

### DIFF
--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -223,6 +223,7 @@ SponsorRegex = psi_utils.recordtype(
 Host = psi_utils.recordtype(
     'Host',
     'id, is_TCS, TCS_type, provider, provider_id, ip_address, ssh_port, ssh_username, ssh_password, ssh_host_key, ' +
+    'ipmi_ip_address, ipmi_username, ipmi_password, ipmi_vpn_profile_location, ' +
     'stats_ssh_username, stats_ssh_password, ' +
     'datacenter_name, region, ' +
     'fronting_provider_id, passthrough_address, passthrough_version, ' +
@@ -482,7 +483,7 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
         if initialize_plugins:
             self.initialize_plugins()
 
-    class_version = '0.70'
+    class_version = '0.71'
 
     def upgrade(self):
         if cmp(parse_version(self.version), parse_version('0.1')) < 0:
@@ -887,6 +888,13 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
         if cmp(parse_version(self.version), parse_version('0.70')) < 0:
             self.__oci_account = OracleAccount()
             self.version = '0.70'
+        if cmp(parse_version(self.version), parse_version('0.71')) < 0:
+            for host in self.__hosts.itervalues():
+                host.ipmi_ip_address = ""
+                host.ipmi_username = ""
+                host.ipmi_password = ""
+                host.ipmi_vpn_profile_location = None
+            self.version = '0.71'
 
     def initialize_plugins(self):
         for plugin in plugins:

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -1193,6 +1193,7 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
             IP Address:              %(ip_address)s
             Region:                  %(region)s
             SSH:                     %(ssh_port)s %(ssh_username)s / %(ssh_password)s
+            IPMI:                    %(ipmi_ip_address)s / %(ipmi_username)s / %(ipmi_password)s / $ipmi_vpn_profile_location) 
             Stats User:              %(stats_ssh_username)s / %(stats_ssh_password)s
             Servers:                 %(servers)s
             ''') % {
@@ -1206,6 +1207,10 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                     'ssh_port': host.ssh_port,
                     'ssh_username': host.ssh_username,
                     'ssh_password': host.ssh_password,
+                    'ipmi_ip_address': host.ipmi_ip_address,
+                    'ipmi_username': host.ipmi_username,
+                    'ipmi_password': host.ipmi_password,
+                    'ipmi_vpn_profile_location': host.ipmi_vpn_profile_location if host.ipmi_vpn_profile_location else 'No VPN Needed',
                     'stats_ssh_username': host.stats_ssh_username,
                     'stats_ssh_password': host.stats_ssh_password,
                     'servers': '\n                         '.join(servers)

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -223,9 +223,9 @@ SponsorRegex = psi_utils.recordtype(
 Host = psi_utils.recordtype(
     'Host',
     'id, is_TCS, TCS_type, provider, provider_id, ip_address, ssh_port, ssh_username, ssh_password, ssh_host_key, ' +
-    'ipmi_ip_address, ipmi_username, ipmi_password, ipmi_vpn_profile_location, ' +
     'stats_ssh_username, stats_ssh_password, ' +
     'datacenter_name, region, ' +
+    'ipmi_ip_address, ipmi_username, ipmi_password, ipmi_vpn_profile_location, ' +
     'fronting_provider_id, passthrough_address, passthrough_version, ' +
     'enable_gquic, limit_quic_versions, ' +
     'meek_server_port, meek_server_obfuscated_key, meek_server_fronting_domain, ' +
@@ -1624,6 +1624,7 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
 
     def get_host_object(self, id, is_TCS, TCS_type, provider, provider_id, ip_address, ssh_port, ssh_username, ssh_password, ssh_host_key,
                         stats_ssh_username, stats_ssh_password, datacenter_name, region,
+                        ipmi_ip_address, ipmi_username, ipmi_password, ipmi_vpn_profile_location,
                         fronting_provider_id, passthrough_address, passthrough_version,
                         enable_gquic, limit_quic_versions,
                         meek_server_port, meek_server_obfuscated_key, meek_server_fronting_domain, meek_server_fronting_host,
@@ -1645,6 +1646,10 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                     stats_ssh_password,
                     datacenter_name,
                     region,
+                    ipmi_ip_address,
+                    ipmi_username,
+                    ipmi_password,
+                    ipmi_vpn_profile_location,
                     fronting_provider_id,
                     passthrough_address,
                     passthrough_version,
@@ -1717,14 +1722,14 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                         host.ssh_username,
                         host.ssh_password,
                         host.ssh_host_key,
-                        host.ipmi_ip_address,
-                        host.ipmi_username,
-                        host.ipmi_password,
-                        host.ipmi_vpn_profile_location,
                         host.stats_ssh_username,
                         host.stats_ssh_password,
                         host.datacenter_name,
                         host.region,
+                        host.ipmi_ip_address,
+                        host.ipmi_username,
+                        host.ipmi_password,
+                        host.ipmi_vpn_profile_location,
                         host.fronting_provider_id,
                         host.passthrough_address,
                         host.passthrough_version,
@@ -2501,14 +2506,14 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                         host.ssh_username,
                         host.ssh_password,
                         host.ssh_host_key,
-                        host.ipmi_ip_address,
-                        host.ipmi_username,
-                        host.ipmi_password,
-                        host.ipmi_vpn_profile_location,
                         host.stats_ssh_username,
                         host.stats_ssh_password,
                         host.datacenter_name,
                         host.region,
+                        host.ipmi_ip_address,
+                        host.ipmi_username,
+                        host.ipmi_password,
+                        host.ipmi_vpn_profile_location,
                         host.fronting_provider_id,
                         host.passthrough_address,
                         host.passthrough_version,
@@ -4338,14 +4343,14 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                                         '',  # Omit: root ssh_username isn't needed
                                         '',  # Omit: root ssh_password isn't needed
                                         '',  # Omit: ssh_host_key isn't needed
-                                        '',  # Omit: host.ipmi_ip_address,
-                                        '',  # Omit: host.ipmi_username,
-                                        '',  # Omit: host.ipmi_password,
-                                        '',  # Omit: host.ipmi_vpn_profile_location,
                                         '',  # Omit: stats_ssh_username isn't needed
                                         '',  # Omit: stats_ssh_password isn't needed
                                         '',  # Omit: datacenter_name isn't needed
                                         host.region,
+                                        '',  # Omit: host.ipmi_ip_address,
+                                        '',  # Omit: host.ipmi_username,
+                                        '',  # Omit: host.ipmi_password,
+                                        '',  # Omit: host.ipmi_vpn_profile_location,
                                         host.fronting_provider_id,
                                         None, # Omit: passthrough_address isn't needed
                                         None, # Omit: passthrough_version isn't needed
@@ -4601,14 +4606,14 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                                             host.ssh_username,
                                             host.ssh_password,
                                             host.ssh_host_key,
-                                            host.ipmi_ip_address,
-                                            host.ipmi_username,
-                                            host.ipmi_password,
-                                            host.ipmi_vpn_profile_location,
                                             host.stats_ssh_username,
                                             host.stats_ssh_password,
                                             host.datacenter_name,
                                             host.region,
+                                            host.ipmi_ip_address,
+                                            host.ipmi_username,
+                                            host.ipmi_password,
+                                            host.ipmi_vpn_profile_location,
                                             host.fronting_provider_id,
                                             host.passthrough_address,
                                             host.passthrough_version,
@@ -4724,14 +4729,14 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                                             '',  # Omit: root ssh username
                                             '',  # Omit: root ssh password
                                             host.ssh_host_key,
-                                            '',  # Omit: host.ipmi_ip_address,
-                                            '',  # Omit: host.ipmi_username,
-                                            '',  # Omit: host.ipmi_password,
-                                            '',  # Omit: host.ipmi_vpn_profile_location,
                                             host.stats_ssh_username,
                                             host.stats_ssh_password,
                                             host.datacenter_name,
                                             host.region,
+                                            '',  # Omit: host.ipmi_ip_address,
+                                            '',  # Omit: host.ipmi_username,
+                                            '',  # Omit: host.ipmi_password,
+                                            '',  # Omit: host.ipmi_vpn_profile_location,
                                             host.fronting_provider_id,
                                             None, # Omit: passthrough_address
                                             None, # Omit: passthrough_version

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -889,7 +889,7 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
             self.__oci_account = OracleAccount()
             self.version = '0.70'
         if cmp(parse_version(self.version), parse_version('0.71')) < 0:
-            for host in self.__hosts.itervalues():
+            for host in self.__hosts.values() + list(self.__deleted_hosts) + list(self.__hosts_to_remove_from_providers):
                 host.ipmi_ip_address = ""
                 host.ipmi_username = ""
                 host.ipmi_password = ""

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -1717,6 +1717,10 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                         host.ssh_username,
                         host.ssh_password,
                         host.ssh_host_key,
+                        host.ipmi_ip_address,
+                        host.ipmi_username,
+                        host.ipmi_password,
+                        host.ipmi_vpn_profile_location,
                         host.stats_ssh_username,
                         host.stats_ssh_password,
                         host.datacenter_name,
@@ -2497,6 +2501,10 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                         host.ssh_username,
                         host.ssh_password,
                         host.ssh_host_key,
+                        host.ipmi_ip_address,
+                        host.ipmi_username,
+                        host.ipmi_password,
+                        host.ipmi_vpn_profile_location,
                         host.stats_ssh_username,
                         host.stats_ssh_password,
                         host.datacenter_name,
@@ -4330,6 +4338,10 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                                         '',  # Omit: root ssh_username isn't needed
                                         '',  # Omit: root ssh_password isn't needed
                                         '',  # Omit: ssh_host_key isn't needed
+                                        '',  # Omit: host.ipmi_ip_address,
+                                        '',  # Omit: host.ipmi_username,
+                                        '',  # Omit: host.ipmi_password,
+                                        '',  # Omit: host.ipmi_vpn_profile_location,
                                         '',  # Omit: stats_ssh_username isn't needed
                                         '',  # Omit: stats_ssh_password isn't needed
                                         '',  # Omit: datacenter_name isn't needed
@@ -4589,6 +4601,10 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                                             host.ssh_username,
                                             host.ssh_password,
                                             host.ssh_host_key,
+                                            host.ipmi_ip_address,
+                                            host.ipmi_username,
+                                            host.ipmi_password,
+                                            host.ipmi_vpn_profile_location,
                                             host.stats_ssh_username,
                                             host.stats_ssh_password,
                                             host.datacenter_name,
@@ -4708,6 +4724,10 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                                             '',  # Omit: root ssh username
                                             '',  # Omit: root ssh password
                                             host.ssh_host_key,
+                                            '',  # Omit: host.ipmi_ip_address,
+                                            '',  # Omit: host.ipmi_username,
+                                            '',  # Omit: host.ipmi_password,
+                                            '',  # Omit: host.ipmi_vpn_profile_location,
                                             host.stats_ssh_username,
                                             host.stats_ssh_password,
                                             host.datacenter_name,

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -1193,7 +1193,7 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
             IP Address:              %(ip_address)s
             Region:                  %(region)s
             SSH:                     %(ssh_port)s %(ssh_username)s / %(ssh_password)s
-            IPMI:                    %(ipmi_ip_address)s / %(ipmi_username)s / %(ipmi_password)s / $ipmi_vpn_profile_location) 
+            IPMI:                    %(ipmi_ip_address)s / %(ipmi_username)s / %(ipmi_password)s / %(ipmi_vpn_profile_location)s
             Stats User:              %(stats_ssh_username)s / %(stats_ssh_password)s
             Servers:                 %(servers)s
             ''') % {


### PR DESCRIPTION
4 Fileds added:
- ipmi_ip_address
- ipmi_username
- ipmi_password
- ipmi_vpn_profile_location (will be None if no VPN needed, otherwise a PATH in secure location)

Add to psinet.show_host()