### PR TITLE
Add manual deploy aurgument to add_servers

### DIFF
--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -2238,8 +2238,9 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
         server_info = provider_launch_new_server_with_retries(is_TCS)
         return server_info[0:3] + (provider.lower(),) + server_info[4:]
 
-    def add_servers(self, server_infos, propagation_channel_name, osl_discovery_date_range, discovery_date_range, replace_others=True, server_capabilities=None):
-        assert(self.is_locked)
+    def add_servers(self, server_infos, propagation_channel_name, osl_discovery_date_range, discovery_date_range, replace_others=True, server_capabilities=None, manual_deploy=False):
+        if manual_deploy != True:
+            assert(self.is_locked)
 
         propagation_channel = self.get_propagation_channel_by_name(propagation_channel_name)
 
@@ -2439,7 +2440,8 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
 
             self.run_command_on_host(host, 'shutdown -r 10')
 
-            self.save()
+            if manual_deploy != True:
+                self.save()
 
         if new_server_error:
             raise Exception(new_server_error)


### PR DESCRIPTION
**Idea:**

When manually deploy dedicated servers, it is always require to modify the `psi_ops.py` file (around Line L2523) in order to by-pass the saving process.

In addition, it is required to manually set `psinet.is_locked = True` to avoid `assert(self.is_locked)` check

Locking psinet is not required when manually deploying dedicated servers. So we should have a flag to avoid those failure.

**Work around patch:***
Having this new `manual_deploy=False` argument set (default to False), and check this argument before running psinet locking and save command.

**Notes:**
Tested it on new dedicated server deployment, works fine (need to set the `manual_deploy=True` when calling the `psinet.add_servers()` method. 

Need to test:
1. Make sure Automation won't break
2. Make sure works well on `python2`
