### PR TITLE
put Android and Windows attachments in separate emails

### DIFF
--- a/Automation/TemplateStrings/en.yaml
+++ b/Automation/TemplateStrings/en.yaml
@@ -9,17 +9,30 @@ en:
         Download Psiphon here: <a href="{{0}}/{0}/download.html#direct">{{0}}/{0}/download.html#direct</a><br>
         </div>
 
-    # The plaintext body of the auto-response email that does have attachments. Please do not modify placeholders such as "{0}", "{{0}}". Note that "{{0}}/{0}/" is part of a URL and spaces should not be inserted.
-    plaintext_email_with_attachment: |+
+    # The plaintext body of the auto-response email has a Windows application attachment. Please do not modify placeholders such as "{0}", "{{0}}". Note that "{{0}}/{0}/" is part of a URL and spaces should not be inserted.
+    plaintext_email_with_windows_attachment: |+
         To use Psiphon 3 for Windows, save the attached file that starts with "psiphon3", and rename it to have a ".exe" extension, if necessary. Then run it.
+        For more information or to download the files again, click the link below.
+        {{0}}/{0}/download.html#direct
+
+    # The HTML body of the auto-response email has a Windows application attachment. Please do not modify placeholders such as "{0}", "{{0}}". Note that "{{0}}/{0}/" is part of a URL and spaces should not be inserted.
+    html_email_with_windows_attachment: |
+        <div style="direction: ltr;">
+        To use Psiphon 3 for Windows, save the attached file that starts with "psiphon3", and rename it to have a ".exe" extension, if necessary. Then run it.<br>
+        For more information or to download the files again, click the link below.<br>
+        <a href="{{0}}/{0}/download.html#direct">{{0}}/{0}/download.html#direct</a><br>
+        </div>
+        <br>
+
+    # The plaintext body of the auto-response email has a Android application attachment. Please do not modify placeholders such as "{0}", "{{0}}". Note that "{{0}}/{0}/" is part of a URL and spaces should not be inserted.
+    plaintext_email_with_android_attachment: |+
         To use Psiphon 3 for Android, save the attached file that starts with "PsiphonAndroid", and rename it to have a ".apk" extension, if necessary. Then install and run it.
         For more information or to download the files again, click the link below.
         {{0}}/{0}/download.html#direct
 
-    # The plaintext body of the auto-response email that does have attachments. Please do not modify placeholders such as "{0}", "{{0}}". Note that "{{0}}/{0}/" is part of a URL and spaces should not be inserted.
-    html_email_with_attachment: |
+    # The HTML body of the auto-response email has a Android application attachment. Please do not modify placeholders such as "{0}", "{{0}}". Note that "{{0}}/{0}/" is part of a URL and spaces should not be inserted.
+    html_email_with_android_attachment: |
         <div style="direction: ltr;">
-        To use Psiphon 3 for Windows, save the attached file that starts with "psiphon3", and rename it to have a ".exe" extension, if necessary. Then run it.<br>
         To use Psiphon 3 for Android, save the attached file that starts with "PsiphonAndroid", and rename it to have a ".apk" extension, if necessary. Then install and run it.<br>
         For more information or to download the files again, click the link below.<br>
         <a href="{{0}}/{0}/download.html#direct">{{0}}/{0}/download.html#direct</a><br>

--- a/Automation/psi_ops.py
+++ b/Automation/psi_ops.py
@@ -3961,40 +3961,45 @@ class PsiphonNetwork(psi_ops_cms.PersistentObject):
                          'send_method': 'SES'
                         })
 
-                    # Email with attachments
-                    attachments = []
+                    # Email with Windows attachment
                     if campaign.platforms == None or CLIENT_PLATFORM_WINDOWS in campaign.platforms:
-                        attachments.append([campaign.s3_bucket_name,
-                                            psi_ops_s3.DOWNLOAD_SITE_WINDOWS_BUILD_FILENAME,
-                                            psi_ops_s3.EMAIL_RESPONDER_WINDOWS_ATTACHMENT_FILENAME])
-                    if campaign.platforms == None or CLIENT_PLATFORM_ANDROID in campaign.platforms:
-                        attachments.append([campaign.s3_bucket_name,
-                                            psi_ops_s3.DOWNLOAD_SITE_ANDROID_BUILD_FILENAME,
-                                            psi_ops_s3.EMAIL_RESPONDER_ANDROID_ATTACHMENT_FILENAME])
-
-                    emails.append(
-                        {
-                         'email_addr': campaign.account.email_address,
-                         'body':
-                            [
-                                ['plain', psi_templates.get_plaintext_attachment_email_content(
+                        emails.append({
+                            'email_addr': campaign.account.email_address,
+                            'body': [
+                                ['plain', psi_templates.get_plaintext_windows_attachment_email_content(
                                                 campaign.s3_bucket_name,
-                                                psi_ops_s3.EMAIL_RESPONDER_WINDOWS_ATTACHMENT_FILENAME,
-                                                psi_ops_s3.EMAIL_RESPONDER_ANDROID_ATTACHMENT_FILENAME,
-                                                campaign.languages,
-                                                campaign.platforms)],
-                                ['html', psi_templates.get_html_attachment_email_content(
+                                                campaign.languages)],
+                                ['html', psi_templates.get_html_windows_attachment_email_content(
                                                 campaign.s3_bucket_name,
-                                                psi_ops_s3.EMAIL_RESPONDER_WINDOWS_ATTACHMENT_FILENAME,
-                                                psi_ops_s3.EMAIL_RESPONDER_ANDROID_ATTACHMENT_FILENAME,
-                                                campaign.languages,
-                                                campaign.platforms)]
+                                                campaign.languages)]
                             ],
-                         'attachments': attachments,
-                         'send_method': 'SMTP'
+                            'attachments': [
+                                [campaign.s3_bucket_name,
+                                 psi_ops_s3.DOWNLOAD_SITE_WINDOWS_BUILD_FILENAME,
+                                 psi_ops_s3.EMAIL_RESPONDER_WINDOWS_ATTACHMENT_FILENAME]
+                            ],
+                            'send_method': 'SMTP'
                         })
-                    # Don't log this, too much noise
-                    #campaign.log('configuring email')
+
+                    # Email with Android attachment
+                    if campaign.platforms == None or CLIENT_PLATFORM_ANDROID in campaign.platforms:
+                        emails.append({
+                            'email_addr': campaign.account.email_address,
+                            'body': [
+                                ['plain', psi_templates.get_plaintext_android_attachment_email_content(
+                                                campaign.s3_bucket_name,
+                                                campaign.languages)],
+                                ['html', psi_templates.get_html_android_attachment_email_content(
+                                                campaign.s3_bucket_name,
+                                                campaign.languages)]
+                            ],
+                            'attachments': [
+                                [campaign.s3_bucket_name,
+                                 psi_ops_s3.DOWNLOAD_SITE_ANDROID_BUILD_FILENAME,
+                                 psi_ops_s3.EMAIL_RESPONDER_ANDROID_ATTACHMENT_FILENAME]
+                            ],
+                            'send_method': 'SMTP'
+                        })
 
         psi_ops_s3.put_string_to_key_in_bucket(self.__aws_account,
                                                self.__automation_bucket,

--- a/Automation/psi_templates.py
+++ b/Automation/psi_templates.py
@@ -136,37 +136,29 @@ def get_html_email_content(
         languages).format(bucket_root_url)
 
 
-def get_plaintext_attachment_email_content(
-        s3_bucket_name,
-        windows_attachment_filename,
-        android_attachment_filename,
-        languages,
-        platforms):
-    # TODO: new attachment strings per platform
-    if platforms != None:
-        return get_plaintext_email_content(s3_bucket_name, languages)
+def get_plaintext_windows_attachment_email_content(s3_bucket_name, languages):
     bucket_root_url = psi_ops_s3.get_s3_bucket_site_root(s3_bucket_name)
     return get_all_languages_string(
-        'plaintext_email_with_attachment',
-        languages).format(
-            bucket_root_url,
-            windows_attachment_filename, # supports legacy translations; can be removed in future release
-            android_attachment_filename) # # supports legacy translations; can be removed in future release
+        'plaintext_email_with_windows_attachment',
+        languages).format(bucket_root_url)
 
 
-def get_html_attachment_email_content(
-        s3_bucket_name,
-        windows_attachment_filename,
-        android_attachment_filename,
-        languages,
-        platforms):
-    # TODO: new attachment strings per platform
-    if platforms != None:
-        return get_html_email_content(s3_bucket_name, languages)
+def get_html_windows_attachment_email_content(s3_bucket_name, languages):
     bucket_root_url = psi_ops_s3.get_s3_bucket_site_root(s3_bucket_name)
     return get_all_languages_string(
-        'html_email_with_attachment',
-        languages).format(
-            bucket_root_url,
-            windows_attachment_filename,
-            android_attachment_filename)
+        'html_email_with_windows_attachment',
+        languages).format(bucket_root_url)
+
+
+def get_plaintext_android_attachment_email_content(s3_bucket_name, languages):
+    bucket_root_url = psi_ops_s3.get_s3_bucket_site_root(s3_bucket_name)
+    return get_all_languages_string(
+        'plaintext_email_with_android_attachment',
+        languages).format(bucket_root_url)
+
+
+def get_html_android_attachment_email_content(s3_bucket_name, languages):
+    bucket_root_url = psi_ops_s3.get_s3_bucket_site_root(s3_bucket_name)
+    return get_all_languages_string(
+        'html_email_with_android_attachment',
+        languages).format(bucket_root_url)


### PR DESCRIPTION
When combined, our file sizes are getting too close to Gmail's 25MB limit.