### PR TITLE
Handle oversized feedback gracefully instead of crashing s3decryptor

### DIFF
--- a/EmailResponder/FeedbackDecryptor/autoresponder.service
+++ b/EmailResponder/FeedbackDecryptor/autoresponder.service
@@ -48,6 +48,7 @@ ExecStop=/bin/kill -s SIGINT $MAINPID
 #Environment=DEBUG=1
 
 WorkingDirectory=fill-in-with-path-to-source
+# TODO: Parameterize venv path
 ExecStart=/opt/psiphon/venv/bin/python service_autoresponder.py
 
 [Install]

--- a/EmailResponder/FeedbackDecryptor/datastore.py
+++ b/EmailResponder/FeedbackDecryptor/datastore.py
@@ -24,7 +24,7 @@ There are currently three tables in our Mongo DB:
   between Psiphon performance and user environment.
 
 - email_diagnostic_info: This is a little less concrete. The short version is:
-  This table indicates that a particlar diagnostic_info record should be
+  This table indicates that a particular diagnostic_info record should be
   formatted and emailed. It might also record additional information (like the
   email ID and subject) about the email that should be sent. Once the diagnostic_info
   has been sent, the associated record is removed from this table.

--- a/EmailResponder/FeedbackDecryptor/mailsender.service
+++ b/EmailResponder/FeedbackDecryptor/mailsender.service
@@ -48,6 +48,7 @@ ExecStop=/bin/kill -s SIGINT $MAINPID
 #Environment=DEBUG=1
 
 WorkingDirectory=fill-in-with-path-to-source
+# TODO: Parameterize venv path
 ExecStart=/opt/psiphon/venv/bin/python service_mailsender.py
 
 [Install]

--- a/EmailResponder/FeedbackDecryptor/s3decryptor.py
+++ b/EmailResponder/FeedbackDecryptor/s3decryptor.py
@@ -24,6 +24,7 @@ import json
 import yaml
 import multiprocessing
 import boto3
+from pymongo.errors import DocumentTooLarge
 
 from config import config
 import logger
@@ -251,11 +252,22 @@ def _process_work_items(work_queue):
             logger.exception()
             logger.error(str(e))
 
+        except DocumentTooLarge as e:
+            metadata = diagnostic_info.get('Metadata', {}) if diagnostic_info else {}
+            logger.error(
+                'DocumentTooLarge: feedback_id=%s platform=%s app=%s version=%s '
+                'encrypted_size=%.1fMB; %s' % (
+                    metadata.get('id'),
+                    metadata.get('platform'),
+                    metadata.get('appName'),
+                    metadata.get('version'),
+                    len(encrypted_info_json) / 1e6,
+                    e))
+
         except Exception as e:
             logger.error(str(e))
             try:
                 import traceback
-                # Something bad happened while decrypting. Report it via email.
                 sender.send_email(config.decryptedEmailRecipient,
                                   config.responseEmailAddress,
                                   'S3Decryptor: unhandled exception',
@@ -264,7 +276,6 @@ def _process_work_items(work_queue):
             except Exception as e:
                 logger.exception()
                 logger.error(str(e))
-            work_queue.put(e)
             raise
 
     logger.debug_log('_process_work_items: done')

--- a/EmailResponder/FeedbackDecryptor/s3decryptor.service
+++ b/EmailResponder/FeedbackDecryptor/s3decryptor.service
@@ -48,6 +48,7 @@ ExecStop=/bin/kill -s SIGINT $MAINPID
 #Environment=DEBUG=1
 
 WorkingDirectory=fill-in-with-path-to-source
+# TODO: Parameterize venv path
 ExecStart=/opt/psiphon/venv/bin/python service_s3decryptor.py
 
 [Install]

--- a/EmailResponder/FeedbackDecryptor/statschecker.service
+++ b/EmailResponder/FeedbackDecryptor/statschecker.service
@@ -48,6 +48,7 @@ ExecStop=/bin/kill -s SIGINT $MAINPID
 #Environment=DEBUG=1
 
 WorkingDirectory=fill-in-with-path-to-source
+# TODO: Parameterize venv path
 ExecStart=/opt/psiphon/venv/bin/python service_statschecker.py
 
 [Install]


### PR DESCRIPTION
DocumentTooLarge from MongoDB was falling through to the generic exception handler, which re-raised and killed the worker process. Additionally, work_queue.put(e) was putting the exception object onto the work queue, where another worker would dequeue it and pass it to json.loads(), causing a cascading TypeError.

Log client metadata (feedback ID, platform, app, version, size) so oversized senders can be identified and the relevant clients fixed.