### PR TITLE
Support Psiphon 4 feedback report schema v2

### DIFF
--- a/EmailResponder/FeedbackDecryptor/autoresponder.py
+++ b/EmailResponder/FeedbackDecryptor/autoresponder.py
@@ -428,6 +428,29 @@ def _get_response_content(response_id, diagnostic_info):
     }
 
 
+# Apps we know have no autoresponse copy. Suppressing one of these is routine;
+# suppressing anything else means the allow-list failed closed on an app name
+# we did not anticipate, which is worth surfacing.
+_KNOWN_UNSUPPORTED_APPS = ('psiphon4', 'ryve', 'conduit')
+
+
+def _suppress_response(diagnostic_info) -> bool:
+    '''
+    Returns True for every app but Psiphon 3. The copy in `responses/` is
+    Psiphon 3's, and the only response an uploaded report from one of those apps
+    can select is `download_new_version_links`, which points at Psiphon 3
+    downloads.
+    An allow-list rather than a deny-list, so that an app added later cannot
+    inherit copy that was never written for it.
+    Checked ahead of `_check_and_add_address_blacklist` so that a suppressed
+    report does not spend the address's daily response slot.
+    '''
+
+    return utils.coalesce(diagnostic_info,
+                          ('Metadata', 'appName'),
+                          required_types=str) != 'psiphon'
+
+
 def _analyze_diagnostic_info(diagnostic_info, reply_info):
     '''
     Determines what response should be sent based on `diagnostic_info` content.
@@ -480,6 +503,38 @@ def _analyze_diagnostic_info(diagnostic_info, reply_info):
     return responses
 
 
+def _suppress_response_test():
+    assert(_suppress_response({'Metadata': {'appName': 'psiphon'}}) is False)
+    assert(_suppress_response({'Metadata': {'appName': 'psiphon4'}}) is True)
+    assert(_suppress_response({'Metadata': {'appName': 'ryve'}}) is True)
+    assert(_suppress_response({'Metadata': {'appName': 'conduit'}}) is True)
+
+    # Fail closed: an unreadable app name is suppressed rather than assumed to
+    # be Psiphon 3 and sent Psiphon 3 copy.
+    assert(_suppress_response(None) is True)
+    assert(_suppress_response({}) is True)
+    assert(_suppress_response({'Metadata': {}}) is True)
+    assert(_suppress_response({'Metadata': {'appName': 1}}) is True)
+    assert(_suppress_response({'Metadata': {'appName': 'Psiphon'}}) is True)
+
+    print('_suppress_response test okay')
+
+_suppress_response.test = _suppress_response_test
+
+
+# TODO: proper unit test framework
+def test():
+    logger.disable()
+
+    for name_in_module in dir(sys.modules[__name__]):
+        testee = getattr(sys.modules[__name__], name_in_module)
+
+        if not hasattr(testee, 'test') or not hasattr(testee.test, '__call__'):
+            continue
+
+        testee.test()
+
+
 def go():
     logger.debug_log('go: enter')
 
@@ -491,6 +546,18 @@ def go():
         email_info = autoresponder_info.get('email_info')
 
         logger.debug_log('go: got autoresponder record')
+
+        if _suppress_response(diagnostic_info):
+            app_name = utils.coalesce(diagnostic_info, ('Metadata', 'appName'))
+            if app_name in _KNOWN_UNSUPPORTED_APPS:
+                logger.debug_log('go: response suppressed for appName=%s' % app_name)
+            else:
+                # debug_log does not emit unless DEBUG is set, which it is not
+                # in production, so an unexpected app name has to log louder or
+                # it leaves no trace at all.
+                logger.log('go: response suppressed for unrecognised appName=%s'
+                           % app_name)
+            continue
 
         # For now we don't do any interesting processing/analysis and we just
         # respond to every feedback with an exhortation to upgrade.

--- a/EmailResponder/FeedbackDecryptor/autoresponder.py
+++ b/EmailResponder/FeedbackDecryptor/autoresponder.py
@@ -428,10 +428,21 @@ def _get_response_content(response_id, diagnostic_info):
     }
 
 
-# Apps we know have no autoresponse copy. Suppressing one of these is routine;
-# suppressing anything else means the allow-list failed closed on an app name
-# we did not anticipate, which is worth surfacing.
+# Apps we know have no autoresponse copy. Suppressing one of these is routine.
+# Anything else means the allow-list caught a name nobody anticipated, which is
+# worth surfacing rather than burying at debug level.
 _KNOWN_UNSUPPORTED_APPS = ('psiphon4', 'ryve', 'conduit')
+
+
+def _app_name(diagnostic_info):
+    '''
+    The app name the suppression decision is made on. Read through one helper
+    so the value that gets logged is always the value that was judged.
+    '''
+
+    return utils.coalesce(diagnostic_info,
+                          ('Metadata', 'appName'),
+                          required_types=str)
 
 
 def _suppress_response(diagnostic_info) -> bool:
@@ -441,14 +452,16 @@ def _suppress_response(diagnostic_info) -> bool:
     can select is `download_new_version_links`, which points at Psiphon 3
     downloads.
     An allow-list rather than a deny-list, so that an app added later cannot
-    inherit copy that was never written for it.
+    inherit copy that was never written for it. It fails closed: a name that is
+    absent, not a string, or spelled unexpectedly is suppressed rather than
+    assumed to be Psiphon 3. Only the last two reach here in practice, because
+    `upgrade_diagnostic_info` stamps a missing name as 'psiphon' before storage
+    -- which Psiphon 3 relies on, since it sends no appName of its own.
     Checked ahead of `_check_and_add_address_blacklist` so that a suppressed
     report does not spend the address's daily response slot.
     '''
 
-    return utils.coalesce(diagnostic_info,
-                          ('Metadata', 'appName'),
-                          required_types=str) != 'psiphon'
+    return _app_name(diagnostic_info) != 'psiphon'
 
 
 def _analyze_diagnostic_info(diagnostic_info, reply_info):
@@ -509,8 +522,11 @@ def _suppress_response_test():
     assert(_suppress_response({'Metadata': {'appName': 'ryve'}}) is True)
     assert(_suppress_response({'Metadata': {'appName': 'conduit'}}) is True)
 
-    # Fail closed: an unreadable app name is suppressed rather than assumed to
-    # be Psiphon 3 and sent Psiphon 3 copy.
+    # appName is required by the v2 schema, and upgrade_diagnostic_info stamps
+    # a missing one as 'psiphon' before storage, so the cases below describe
+    # this function's contract rather than paths the pipeline delivers. The two
+    # that do survive that backfill are a truthy non-string and an unexpected
+    # spelling; those are what go()'s unrecognised-appName log line is for.
     assert(_suppress_response(None) is True)
     assert(_suppress_response({}) is True)
     assert(_suppress_response({'Metadata': {}}) is True)
@@ -547,16 +563,23 @@ def go():
 
         logger.debug_log('go: got autoresponder record')
 
-        if _suppress_response(diagnostic_info):
-            app_name = utils.coalesce(diagnostic_info, ('Metadata', 'appName'))
+        if diagnostic_info is None:
+            # The autoresponder collection has no TTL but diagnostic_info
+            # expires after 26 weeks, so a backlogged record can outlive the
+            # document it points at. Nothing to judge and nothing to reply to.
+            if not email_info:
+                logger.debug_log('go: diagnostic_info not found; skipping')
+                continue
+        elif _suppress_response(diagnostic_info):
+            app_name = _app_name(diagnostic_info)
             if app_name in _KNOWN_UNSUPPORTED_APPS:
                 logger.debug_log('go: response suppressed for appName=%s' % app_name)
             else:
-                # debug_log does not emit unless DEBUG is set, which it is not
-                # in production, so an unexpected app name has to log louder or
-                # it leaves no trace at all.
-                logger.log('go: response suppressed for unrecognised appName=%s'
-                           % app_name)
+                # debug_log does not emit unless DEBUG is set, and log only
+                # reaches syslog. error also records to the datastore, which is
+                # what surfaces in the daily stats email.
+                logger.error('go: response suppressed for unrecognised appName=%s'
+                             % app_name)
             continue
 
         # For now we don't do any interesting processing/analysis and we just

--- a/EmailResponder/FeedbackDecryptor/datatransformer.py
+++ b/EmailResponder/FeedbackDecryptor/datatransformer.py
@@ -28,7 +28,10 @@ _country_dialing_codes = json.load(open('country_dialing_codes.json'))
 
 
 def _translate_feedback(data):
-    if data.get('Feedback', {}).get('Message'):
+    # Gate on the text, not on the Message object: a message carrying any other
+    # key would raise KeyError below, and an empty or null text is a wasted
+    # Translate call that stores [TRANSLATION_FAIL] against the report.
+    if data.get('Feedback', {}).get('Message', {}).get('text'):
         trans = translation.translate(config.googleApiServers,
                                       config.googleApiKey,
                                       data['Feedback']['Message']['text'])

--- a/EmailResponder/FeedbackDecryptor/datatransformer.py
+++ b/EmailResponder/FeedbackDecryptor/datatransformer.py
@@ -18,6 +18,7 @@
 import json
 import datetime
 import sys
+import logger
 import translation
 import utils
 from config import config
@@ -28,10 +29,11 @@ _country_dialing_codes = json.load(open('country_dialing_codes.json'))
 
 
 def _translate_feedback(data):
-    # Gate on the text, not on the Message object: a message carrying any other
-    # key would raise KeyError below, and an empty or null text is a wasted
-    # Translate call that stores [TRANSLATION_FAIL] against the report.
-    if data.get('Feedback', {}).get('Message', {}).get('text'):
+    # Read the whole path tolerantly. A legacy report can carry a null or
+    # non-dict Feedback or Message, and chained .get raises on those; gating on
+    # the Message object instead lets a message without a text key raise below.
+    # Either way the worker exits and takes its in-flight reports with it.
+    if utils.coalesce(data, ('Feedback', 'Message', 'text')):
         trans = translation.translate(config.googleApiServers,
                                       config.googleApiKey,
                                       data['Feedback']['Message']['text'])
@@ -182,6 +184,58 @@ def _ensure_field_is_type(targettype, data, fieldpath):
     prev_val = utils.coalesce(data, fieldpath)
     if prev_val is not None:
         utils.assign_value_to_obj_at_path(data, fieldpath, targettype(prev_val))
+
+
+def _translate_feedback_test():
+    calls = []
+    real_translate = translation.translate
+    translation.translate = lambda servers, key, text: (
+        calls.append(text) or ('en', 'English', text))
+
+    try:
+        # Only a truthy text reaches the translator. Every other shape is
+        # skipped rather than raising: this gate runs on legacy PascalCase
+        # reports too, and an exception here exits the s3decryptor worker,
+        # losing whatever it had already taken off S3.
+        translated = {'Feedback': {'Message': {'text': 'hello'}}}
+        skipped = [
+            {'Feedback': {'Message': {'text': None}}},
+            {'Feedback': {'Message': {'text': ''}}},
+            {'Feedback': {'Message': {'notes': 'no text key'}}},
+            {'Feedback': {'Message': {}}},
+            {'Feedback': {'Message': None}},
+            {'Feedback': {'Message': 'not a dict'}},
+            {'Feedback': None},
+            {},
+        ]
+
+        _translate_feedback(translated)
+        assert(calls == ['hello'])
+        assert(translated['Feedback']['Message']['text_lang_code'] == 'en')
+        assert(translated['Feedback']['Message']['text_translated'] == 'hello')
+
+        for data in skipped:
+            _translate_feedback(data)
+        assert(calls == ['hello'])
+    finally:
+        translation.translate = real_translate
+
+    print('_translate_feedback test okay')
+
+_translate_feedback.test = _translate_feedback_test
+
+
+# TODO: proper unit test framework
+def test():
+    logger.disable()
+
+    for name_in_module in dir(sys.modules[__name__]):
+        testee = getattr(sys.modules[__name__], name_in_module)
+
+        if not hasattr(testee, 'test') or not hasattr(testee.test, '__call__'):
+            continue
+
+        testee.test()
 
 
 def transform(data):

--- a/EmailResponder/FeedbackDecryptor/mailformatter.py
+++ b/EmailResponder/FeedbackDecryptor/mailformatter.py
@@ -15,10 +15,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import datetime
+import sys
+
 from mako.template import Template
 from mako.lookup import TemplateLookup
 from mako import exceptions
 import pynliner
+
+import logger
 
 
 _cached_templates = {}
@@ -52,6 +57,8 @@ def format(data):
         platform = 'ios'
     elif data['Metadata']['platform'] in ['ios-vpn-on-mac', 'ios-app-on-mac']:
         platform = 'ios-app-on-mac'
+    elif data['Metadata']['platform'] == 'macos':
+        platform = 'macos'
     else:
         platform = 'android'
 
@@ -93,3 +100,161 @@ def format(data):
     rendered = pynliner.fromString(rendered)
 
     return rendered
+
+
+def _generate_psiphon4_v2_feedback(platform, message, extra_blocks=None):
+    '''
+    A Psiphon 4 feedback report v2, camelCase throughout, as the client uploads
+    it, then put through the two intake steps that reshape what the template
+    reads: `utils.normalize_lowercase_envelope` and
+    `datatransformer._postprocess_yaml`. Replaying those rather than hardcoding
+    their output keeps the fixture from drifting from what `format` receives.
+    The other intake steps are not replayed: translation needs the network and
+    the psinet lookup needs psinet, redaction only rewrites string leaves, and
+    `_sanitize_keys` only touches keys containing a dot, which this fixture has
+    none of.
+    `message` is the feedback message object, including any translation fields
+    `datatransformer._translate_feedback` would have added to it in place.
+    '''
+
+    import utils
+    import datatransformer
+
+    data = {
+        'metadata': {
+            'appName': 'psiphon4',
+            'platform': platform,
+            'version': 2,
+            'id': 'A1B2C3D4E5F60718',
+            'date!!timestamp': '2026-09-02T10:00:00.000Z',
+        },
+        'system': {
+            'device': {'model': 'iPhone16,2', 'localizedModel': 'iPhone'},
+            'os': {'name': 'iOS', 'version': '26.0'},
+            'locale': 'fa-IR',
+            'networkType': 'cellular',
+            'jailbreakDetected': False,
+        },
+        'app': {
+            'appId': 'ca.psiphon.psiphon4',
+            'version': '2.5.2',
+            'buildNumber': '46',
+            'buildMode': 'release',
+            'internalTest': True,
+            'locale': 'fa',
+            'gitDescribe': 'v2.5.2-3-gabcdef0',
+            'propagationChannelId': 'ExamplePropagationChannel',
+            'sponsorId': 'ExampleSponsor',
+            'tunnelCore': {'buildRev': 'abcdef0', 'goVersion': 'go1.24'},
+        },
+        'logs': [
+            {
+                'timestamp!!timestamp': '2026-09-02T09:59:00.000Z',
+                'category': 'tunnel-core',
+                'data': {'noticeType': 'ConnectedServer', 'data': {'ipAddress': 'server-1'}},
+            },
+            {
+                'timestamp!!timestamp': '2026-09-02T09:59:30.000Z',
+                'category': 'native',
+                'level': 'Info',
+                'message': 'tunnel connected',
+                'data': {'tag': 'VPNManager'},
+            },
+            {
+                'timestamp!!timestamp': '2026-09-02T09:59:31.000Z',
+                'category': 'frontend',
+                'level': 'Debug',
+                'message': 'should be skipped',
+                'data': {'tag': 'HomeScreen'},
+            },
+        ],
+        'feedback': {'message': message},
+    }
+
+    if extra_blocks:
+        data.update(extra_blocks)
+
+    utils.normalize_lowercase_envelope(data)
+    datatransformer._postprocess_yaml(data)
+
+    return data
+
+
+def format_test():
+    # A report with a translated message, no diagnostics block.
+    data = _generate_psiphon4_v2_feedback(
+        'ios',
+        {'text': 'کار نمی\u200cکند', 'text_lang_code': 'fa',
+         'text_lang_name': 'Persian', 'text_translated': 'does not work'})
+
+    assert('metadata' not in data and 'feedback' not in data)
+    assert(isinstance(data['Metadata']['date'], datetime.datetime))
+    assert(isinstance(data['logs'][0]['timestamp'], datetime.datetime))
+
+    rendered = format(data)
+    assert('Psiphon 4' in rendered)
+    assert('does not work' in rendered)
+    assert('Auto-translated from Persian' in rendered)
+    # Asserting on the notice type alone would also pass if log_row dumped the
+    # whole entry, so require that the key itself is absent.
+    assert('ConnectedServer' in rendered)
+    assert('noticeType' not in rendered)
+    assert('tunnel connected' in rendered)
+    # Trace and debug lines are below the threshold we print.
+    assert('should be skipped' not in rendered)
+    assert('ExampleSponsor' in rendered)
+    assert('v2.5.2-3-gabcdef0' in rendered)
+    assert('Jailbreak detected' in rendered)
+
+    # A diagnostics-only report from Android.
+    data = _generate_psiphon4_v2_feedback(
+        'android', {},
+        {'diagnostics': {'crashHistory': ['panic: example']},
+         'system': {
+             'device': {'brand': 'google', 'manufacturer': 'Google', 'model': 'Pixel 9'},
+             'os': {'version': '16', 'sdkInt': 36},
+             'locale': 'en-CA',
+             'networkType': 'wifi',
+             'rootDetected': False,
+         }})
+    rendered = format(data)
+    assert('panic: example' in rendered)
+    assert('Root detected' in rendered)
+    assert('Jailbreak detected' not in rendered)
+    # brand and manufacturer differ only in case on Pixel hardware.
+    assert('Google Pixel 9' in rendered)
+    assert('google Google' not in rendered)
+    assert('google Pixel 9' not in rendered)
+
+    # A timestamp _postprocess_yaml cannot parse stays a string under its
+    # original key. The render must survive it.
+    unparsed = '2026-09-02T09:59:00+00:00'
+    data = _generate_psiphon4_v2_feedback(
+        'ios', {'text': 'hello'},
+        {'logs': [{'timestamp!!timestamp': unparsed,
+                   'category': 'native',
+                   'level': 'Info',
+                   'message': 'odd timestamp',
+                   'data': {'tag': 'VPNManager'}}]})
+    assert(data['logs'][0]['timestamp!!timestamp'] == unparsed)
+    rendered = format(data)
+    assert(unparsed in rendered)
+    assert('odd timestamp' in rendered)
+
+    print('mailformatter format test okay')
+
+
+format.test = format_test
+
+
+# TODO: proper unit test framework
+def test():
+    logger.disable()
+
+    for name_in_module in dir(sys.modules[__name__]):
+        testee = getattr(sys.modules[__name__], name_in_module)
+
+        if not hasattr(testee, 'test') or not hasattr(testee.test, '__call__'):
+            continue
+
+        testee.test()

--- a/EmailResponder/FeedbackDecryptor/mailformatter.py
+++ b/EmailResponder/FeedbackDecryptor/mailformatter.py
@@ -242,9 +242,11 @@ def format_test():
     assert('panic: example' in rendered)
     assert('Root detected' in rendered)
     assert('Jailbreak detected' not in rendered)
-    # brand and manufacturer differ only in case on Pixel hardware.
+    # brand and manufacturer differ only in case on Pixel hardware. The first
+    # assertion catches a dedupe failure, which would read "Google google
+    # Pixel 9"; the second catches brand winning over the better-cased
+    # manufacturer.
     assert('Google Pixel 9' in rendered)
-    assert('google Google' not in rendered)
     assert('google Pixel 9' not in rendered)
 
     # A timestamp _postprocess_yaml cannot parse stays a string under its

--- a/EmailResponder/FeedbackDecryptor/mailformatter.py
+++ b/EmailResponder/FeedbackDecryptor/mailformatter.py
@@ -117,6 +117,9 @@ def _generate_psiphon4_v2_feedback(platform, message, extra_blocks=None):
     `datatransformer._translate_feedback` would have added to it in place.
     '''
 
+    # Deferred: this is fixture-only, and datatransformer pulls in translation
+    # and requests. Importing at module scope would add those to mailsender's
+    # import graph in production for no reason.
     import utils
     import datatransformer
 
@@ -152,6 +155,11 @@ def _generate_psiphon4_v2_feedback(platform, message, extra_blocks=None):
                 'timestamp!!timestamp': '2026-09-02T09:59:00.000Z',
                 'category': 'tunnel-core',
                 'data': {'noticeType': 'ConnectedServer', 'data': {'ipAddress': 'server-1'}},
+            },
+            {
+                'timestamp!!timestamp': '2026-09-02T09:59:15.000Z',
+                'category': 'tunnel-core',
+                'data': {'noticeType': 'Info', 'data': {'message': 'sole message field'}},
             },
             {
                 'timestamp!!timestamp': '2026-09-02T09:59:30.000Z',
@@ -200,6 +208,19 @@ def format_test():
     assert('ConnectedServer' in rendered)
     assert('noticeType' not in rendered)
     assert('tunnel connected' in rendered)
+    # A single-field payload is promoted out of its dict repr; a payload with
+    # more than one key is still dumped whole.
+    assert('sole message field' in rendered)
+    # Compare against tag-stripped, unescaped text: the rendered repr has its
+    # quotes HTML-escaped, and the promoted values contain the key names.
+    import html as html_module
+    import re as re_module
+    logs_text = html_module.unescape(
+        re_module.sub('<[^>]+>', ' ', rendered.split('Logs')[-1]))
+    assert('sole message field' in logs_text and "{'message'" not in logs_text)
+    assert('VPNManager' in logs_text and "{'tag'" not in logs_text)
+    # A payload with a key we do not promote is still dumped whole.
+    assert("{'ipAddress': 'server-1'}" in logs_text)
     # Trace and debug lines are below the threshold we print.
     assert('should be skipped' not in rendered)
     assert('ExampleSponsor' in rendered)

--- a/EmailResponder/FeedbackDecryptor/s3decryptor.py
+++ b/EmailResponder/FeedbackDecryptor/s3decryptor.py
@@ -194,6 +194,10 @@ def _process_work_items(work_queue):
                 # Also throw, so we get an email about it
                 raise Exception('diagnostic_info unmarshalled empty')
 
+            # Modifies diagnostic_info. Must run before the sanity check, which
+            # requires the normalized envelope.
+            utils.normalize_lowercase_envelope(diagnostic_info)
+
             logger.log('feedback id: {0}; size: {1:.1f} MB'.format(diagnostic_info.get('Metadata', {}).get('id'), len(encrypted_info_json)/1e6))
 
             if not utils.is_diagnostic_info_sane(diagnostic_info):

--- a/EmailResponder/FeedbackDecryptor/s3decryptor.py
+++ b/EmailResponder/FeedbackDecryptor/s3decryptor.py
@@ -198,7 +198,12 @@ def _process_work_items(work_queue):
             # requires the normalized envelope.
             utils.normalize_lowercase_envelope(diagnostic_info)
 
-            logger.log('feedback id: {0}; size: {1:.1f} MB'.format(diagnostic_info.get('Metadata', {}).get('id'), len(encrypted_info_json)/1e6))
+            # coalesce rather than chained .get, because the payload is only
+            # known to be non-empty at this point; a decrypted body that parses
+            # to a list or a string would raise on .get and take the worker down.
+            logger.log('feedback id: {0}; size: {1:.1f} MB'.format(
+                utils.coalesce(diagnostic_info, ('Metadata', 'id')),
+                len(encrypted_info_json)/1e6))
 
             if not utils.is_diagnostic_info_sane(diagnostic_info):
                 # Something is wrong. Skip and continue.

--- a/EmailResponder/FeedbackDecryptor/templates/template_psiphon4_2.mako
+++ b/EmailResponder/FeedbackDecryptor/templates/template_psiphon4_2.mako
@@ -45,6 +45,19 @@
       parts.append(str(value))
     return ' '.join(parts)
 
+  def qualified(value, detail):
+    ## Space-joining two numbers reads as one value: a version and build number
+    ## become "2.5.3 47", and an Android OS version and SDK level "17 37".
+    if value and detail:
+      return '%s (%s)' % (value, detail)
+    return value or detail or ''
+
+  ## os.name is iOS only. The schema leaves it out on Android because
+  ## metadata.platform already carries it, so fall back to that.
+  os_name = os_info.get('name') or str(metadata.get('platform', '')).capitalize()
+  os_summary = ' '.join(str(part) for part in (os_name, os_info.get('version')) if part)
+  os_sdk = 'SDK %s' % os_info['sdkInt'] if os_info.get('sdkInt') else None
+
   ## A date _postprocess_yaml could not parse keeps its original key and stays
   ## a string, same as the log timestamps.
   date = metadata.get('date') or metadata.get('date!!timestamp')
@@ -54,7 +67,7 @@
     ('Date', utils.timestamp_display(date) if hasattr(date, 'year') else date),
     ('Platform', metadata.get('platform')),
     ('App ID', app.get('appId')),
-    ('Version', join_present(app, ('version', 'buildNumber'))),
+    ('Version', qualified(app.get('version'), app.get('buildNumber'))),
     ('Build mode', app.get('buildMode')),
     ('Internal test', app.get('internalTest')),
     ('Git describe', app.get('gitDescribe')),
@@ -63,7 +76,7 @@
     ('App locale', app.get('locale')),
     ('Device locale', system.get('locale')),
     ('Device', join_present(device, ('manufacturer', 'brand', 'model'))),
-    ('OS', join_present(os_info, ('name', 'version', 'sdkInt'))),
+    ('OS', qualified(os_summary, os_sdk)),
     ('Network', system.get('networkType')),
     ## Root and jailbreak detection are deliberately not one shared key: they
     ## are different mechanisms. A platform sends its own flag and not the

--- a/EmailResponder/FeedbackDecryptor/templates/template_psiphon4_2.mako
+++ b/EmailResponder/FeedbackDecryptor/templates/template_psiphon4_2.mako
@@ -45,7 +45,9 @@
       parts.append(str(value))
     return ' '.join(parts)
 
-  date = metadata.get('date')
+  ## A date _postprocess_yaml could not parse keeps its original key and stays
+  ## a string, same as the log timestamps.
+  date = metadata.get('date') or metadata.get('date!!timestamp')
 
   summary = [
     ('Feedback ID', metadata.get('id')),
@@ -63,14 +65,12 @@
     ('Device', join_present(device, ('manufacturer', 'brand', 'model'))),
     ('OS', join_present(os_info, ('name', 'version', 'sdkInt'))),
     ('Network', system.get('networkType')),
+    ## Root and jailbreak detection are deliberately not one shared key: they
+    ## are different mechanisms. A platform sends its own flag and not the
+    ## other, so the absent one drops out on the None filter below.
+    ('Root detected', system.get('rootDetected')),
+    ('Jailbreak detected', system.get('jailbreakDetected')),
   ]
-
-  ## Root and jailbreak detection are deliberately not one shared key: they are
-  ## different mechanisms. Only one of them is ever present.
-  if 'rootDetected' in system:
-    summary.append(('Root detected', system['rootDetected']))
-  elif 'jailbreakDetected' in system:
-    summary.append(('Jailbreak detected', system['jailbreakDetected']))
 %>
 
 <style>
@@ -97,10 +97,6 @@
     font-weight: bold;
   }
 
-  .log-entry .log-level-debug {
-    color: gray;
-  }
-
   .log-entry-data {
     font-family: monospace;
     font-weight: normal;
@@ -113,16 +109,7 @@
     height: 1px;
   }
 
-  .english_message {
-    margin: 1em 0px;
-    border-left-width: 4px;
-    border-left-style: solid;
-    border-left-color: rgb(221, 221, 221);
-    padding: 0px 1em;
-    /* This renders newlines as newlines */
-    white-space: pre-wrap;
-  }
-
+  .english_message,
   .original_message {
     margin: 1em 0px;
     border-left-width: 4px;
@@ -218,7 +205,7 @@
 ## their keys.
 ##
 
-% if device or os_info:
+% if system:
   <h2>System</h2>
   <pre>
 ${yaml.dump(system, default_flow_style=False, allow_unicode=True)}
@@ -239,12 +226,11 @@ ${yaml.dump(diagnostics, default_flow_style=False, allow_unicode=True)}
   </pre>
 % endif
 
-% if metadata:
-  <h2>Metadata</h2>
-  <pre>
+## Always present: format() has already indexed data['Metadata'].
+<h2>Metadata</h2>
+<pre>
 ${yaml.dump(metadata, default_flow_style=False, allow_unicode=True)}
-  </pre>
-% endif
+</pre>
 
 ##
 ## Logs
@@ -265,7 +251,16 @@ ${yaml.dump(metadata, default_flow_style=False, allow_unicode=True)}
       payload = entry_data
 
     level = entry.get('level')
-    log_level_class = level.lower() if level else 'none'
+
+    ## Most rows carry a single-value payload: a tunnel-core notice is usually
+    ## just {'message': ...} and a native or frontend line just {'tag': ...}.
+    ## A dict repr buries the only useful value, and these are the bulk of a
+    ## real report. Anything with a second key is dumped whole.
+    payload_text = repr(payload) if payload else ''
+    for sole_key in ('message', 'tag'):
+      if list(payload) == [sole_key] and isinstance(payload[sole_key], str):
+        payload_text = payload[sole_key]
+        break
 
     ## A timestamp that failed to parse keeps its `!!timestamp` key and stays a
     ## string, so there may be no datetime to diff against.
@@ -286,14 +281,14 @@ ${yaml.dump(metadata, default_flow_style=False, allow_unicode=True)}
   <div class="log-entry">
     <span class="timestamp">${timestamp_display}</span>
 
-    <span class="log-entry-message log-level-${log_level_class}">
+    <span class="log-entry-message">
       ${category}
       % if level:
         [${level}]:
       % endif
       ${headline}
-      % if payload:
-        <span class="log-entry-data">${repr(payload)}</span>
+      % if payload_text:
+        <span class="log-entry-data">${payload_text}</span>
       % endif
     </span>
   </div>

--- a/EmailResponder/FeedbackDecryptor/templates/template_psiphon4_2.mako
+++ b/EmailResponder/FeedbackDecryptor/templates/template_psiphon4_2.mako
@@ -1,0 +1,318 @@
+## Copyright (c) 2026, Psiphon Inc.
+## All rights reserved.
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+<%!
+  import yaml
+  import utils
+%>
+
+<%
+  ## `Metadata` and `Feedback` are normalized by utils.normalize_lowercase_envelope;
+  ## the remaining blocks stay in the lowercase shape the client sent.
+  metadata = data['Metadata']
+  feedback_info = data.get('Feedback', {})
+  system = data.get('system', {})
+  app = data.get('app', {})
+  logs = data.get('logs', [])
+  diagnostics = data.get('diagnostics', {})
+
+  device = system.get('device', {})
+  os_info = system.get('os', {})
+  tunnel_core = app.get('tunnelCore', {})
+
+  def join_present(obj, keys):
+    ## brand and manufacturer often differ only in case, as with Google and
+    ## google on Pixel hardware. The first spelling wins, so pass it first.
+    parts, seen = [], set()
+    for k in keys:
+      value = obj.get(k)
+      if value in (None, '') or str(value).lower() in seen:
+        continue
+      seen.add(str(value).lower())
+      parts.append(str(value))
+    return ' '.join(parts)
+
+  date = metadata.get('date')
+
+  summary = [
+    ('Feedback ID', metadata.get('id')),
+    ('Date', utils.timestamp_display(date) if hasattr(date, 'year') else date),
+    ('Platform', metadata.get('platform')),
+    ('App ID', app.get('appId')),
+    ('Version', join_present(app, ('version', 'buildNumber'))),
+    ('Build mode', app.get('buildMode')),
+    ('Internal test', app.get('internalTest')),
+    ('Git describe', app.get('gitDescribe')),
+    ('Sponsor', app.get('sponsorId')),
+    ('Propagation channel', app.get('propagationChannelId')),
+    ('App locale', app.get('locale')),
+    ('Device locale', system.get('locale')),
+    ('Device', join_present(device, ('manufacturer', 'brand', 'model'))),
+    ('OS', join_present(os_info, ('name', 'version', 'sdkInt'))),
+    ('Network', system.get('networkType')),
+  ]
+
+  ## Root and jailbreak detection are deliberately not one shared key: they are
+  ## different mechanisms. Only one of them is ever present.
+  if 'rootDetected' in system:
+    summary.append(('Root detected', system['rootDetected']))
+  elif 'jailbreakDetected' in system:
+    summary.append(('Jailbreak detected', system['jailbreakDetected']))
+%>
+
+<style>
+  th {
+    text-align: right;
+    padding-right: 0.3em;
+    vertical-align: top;
+  }
+
+  td {
+    vertical-align: top;
+  }
+
+  .log-entry {
+    margin-bottom: 0.3em;
+  }
+
+  .timestamp {
+    font-size: 0.8em;
+    font-family: monospace;
+  }
+
+  .log-entry-message {
+    font-weight: bold;
+  }
+
+  .log-entry .log-level-debug {
+    color: gray;
+  }
+
+  .log-entry-data {
+    font-family: monospace;
+    font-weight: normal;
+  }
+
+  hr {
+    width: 80%;
+    border: 0;
+    background-color: lightGray;
+    height: 1px;
+  }
+
+  .english_message {
+    margin: 1em 0px;
+    border-left-width: 4px;
+    border-left-style: solid;
+    border-left-color: rgb(221, 221, 221);
+    padding: 0px 1em;
+    /* This renders newlines as newlines */
+    white-space: pre-wrap;
+  }
+
+  .original_message {
+    margin: 1em 0px;
+    border-left-width: 4px;
+    border-left-style: solid;
+    border-left-color: rgb(221, 221, 221);
+    padding: 0px 1em;
+    /* This renders newlines as newlines */
+    white-space: pre-wrap;
+  }
+
+  .smaller {
+    font-size: 0.8em;
+  }
+
+  .rtl {
+    direction: rtl;
+  }
+</style>
+
+
+<h1>Psiphon 4</h1>
+
+% if feedback_info and feedback_info.get('Message') and feedback_info['Message'].get('text'):
+<%
+  message = feedback_info['Message']
+  msg_text = message['text']
+
+  # Through experimentation, we have found that the maximum number of urlencoded
+  # UTF-8 characters that can successfully be put into a Google Translate URL
+  # is about 600. So if there are more characters than that, we'll just link
+  # to the blank form.
+  gtranslate_url = 'https://translate.google.com/#auto/en/'
+  urlencoded_msg = utils.urlencode(msg_text)
+  if len(urlencoded_msg) < 600:
+    gtranslate_url += urlencoded_msg
+
+  lang_code = message.get('text_lang_code')
+  translated = message.get('text_translated')
+
+  # There are some special values that text_lang_code might have that indicate
+  # a problem during translation.
+  no_translation = lang_code in ('[INDETERMINATE]', '[TRANSLATION_FAIL]')
+
+  direction = 'rtl' if lang_code in ('fa', 'ar', 'iw', 'yi') else ''
+%>
+
+  <h2>Feedback</h2>
+
+  % if lang_code and not no_translation:
+    <div class="english_message">${translated}</div>
+
+    % if msg_text != translated:
+      <div class="smaller">
+        Auto-translated from ${message['text_lang_name']}.
+      </div>
+      <br>
+
+      <div class="original_message ${direction}">${msg_text}</div>
+
+      <div class="smaller">
+        <a href="${gtranslate_url}">Google Translate.</a>
+      </div>
+    % endif
+  % else:
+    % if no_translation:
+      <div class="smaller">Auto-translate failed: ${message['text_lang_name']}</div>
+    % endif
+
+    <div class="original_message ${direction}">${msg_text}</div>
+
+    <div class="smaller">
+      <a href="${gtranslate_url}">Google Translate.</a>
+    </div>
+  % endif
+% endif
+
+% if feedback_info.get('email'):
+  <p>Reply address: ${feedback_info['email']}</p>
+% endif
+
+<h2>Summary</h2>
+<table>
+  % for label, value in summary:
+    % if value is not None and value != '':
+      <tr><th>${label}</th><td>${value}</td></tr>
+    % endif
+  % endfor
+</table>
+
+##
+## The schema leaves these blocks opaque, because that is where the platforms
+## diverge or a third party owns the contents. Dump them rather than modelling
+## their keys.
+##
+
+% if device or os_info:
+  <h2>System</h2>
+  <pre>
+${yaml.dump(system, default_flow_style=False, allow_unicode=True)}
+  </pre>
+% endif
+
+% if tunnel_core:
+  <h2>Tunnel Core</h2>
+  <pre>
+${yaml.dump(tunnel_core, default_flow_style=False, allow_unicode=True)}
+  </pre>
+% endif
+
+% if diagnostics:
+  <h2>Diagnostics</h2>
+  <pre>
+${yaml.dump(diagnostics, default_flow_style=False, allow_unicode=True)}
+  </pre>
+% endif
+
+% if metadata:
+  <h2>Metadata</h2>
+  <pre>
+${yaml.dump(metadata, default_flow_style=False, allow_unicode=True)}
+  </pre>
+% endif
+
+##
+## Logs
+##
+
+<%def name="log_row(entry, last_timestamp)">
+  <%
+    ## A tunnel-core line carries no level or message; its payload is a notice
+    ## nested under data. Every other line has a level, a message, and a tag.
+    category = entry.get('category', '')
+    entry_data = entry.get('data') or {}
+
+    if category == 'tunnel-core':
+      headline = entry_data.get('noticeType') or '(no noticeType)'
+      payload = entry_data.get('data') or {}
+    else:
+      headline = entry.get('message', '')
+      payload = entry_data
+
+    level = entry.get('level')
+    log_level_class = level.lower() if level else 'none'
+
+    ## A timestamp that failed to parse keeps its `!!timestamp` key and stays a
+    ## string, so there may be no datetime to diff against.
+    timestamp = entry.get('timestamp')
+    if hasattr(timestamp, 'year'):
+      timestamp_diff_secs, timestamp_diff_str = utils.get_timestamp_diff(last_timestamp, timestamp)
+      timestamp_display = '%s [+%ss]' % (utils.timestamp_display(timestamp), timestamp_diff_str)
+    else:
+      timestamp_diff_secs = 0
+      timestamp_display = str(entry.get('timestamp!!timestamp') or '(no timestamp)')
+  %>
+
+  ## Put a separator between entries that are separated in time.
+  % if timestamp_diff_secs > 10:
+    <hr>
+  % endif
+
+  <div class="log-entry">
+    <span class="timestamp">${timestamp_display}</span>
+
+    <span class="log-entry-message log-level-${log_level_class}">
+      ${category}
+      % if level:
+        [${level}]:
+      % endif
+      ${headline}
+      % if payload:
+        <span class="log-entry-data">${repr(payload)}</span>
+      % endif
+    </span>
+  </div>
+</%def>
+
+<h2>Logs</h2>
+<%
+  last_timestamp = None
+%>
+% for entry in logs:
+  ## level may be absent or null
+  % if entry.get('level') and entry['level'].lower() in ('trace', 'debug'):
+    ## info is the minimum we'll print
+    <% continue %>
+  % endif
+
+  ${log_row(entry, last_timestamp)}
+  <%
+    if hasattr(entry.get('timestamp'), 'year'):
+      last_timestamp = entry['timestamp']
+  %>
+% endfor

--- a/EmailResponder/FeedbackDecryptor/utils.py
+++ b/EmailResponder/FeedbackDecryptor/utils.py
@@ -189,7 +189,9 @@ def convert_psinet_values(config, obj):
                 clean_val = ''.join(split)
                 assign_value_to_obj_at_path(obj, path, clean_val)
 
-        if path[-1] == 'PROPAGATION_CHANNEL_ID':
+        # Modern clients (Psiphon 4 feedback report v2) carry these under `app`
+        # in camelCase; older clients use PsiphonInfo and SCREAMING_SNAKE.
+        if path[-1] in ('PROPAGATION_CHANNEL_ID', 'propagationChannelId'):
             prop_channel_name = prop_channel_id_to_name.get(val)
             if not prop_channel_name:
                 prop_channel_name = psi_ops_helpers.get_propagation_channel_name_by_id(val)
@@ -199,7 +201,7 @@ def convert_psinet_values(config, obj):
                 assign_value_to_obj_at_path(obj,
                                             path,
                                             prop_channel_name)
-        elif path[-1] == 'SPONSOR_ID':
+        elif path[-1] in ('SPONSOR_ID', 'sponsorId'):
             sponsor_name = sponsor_id_to_name.get(val)
             if not sponsor_name:
                 sponsor_name = psi_ops_helpers.get_sponsor_name_by_id(val)
@@ -230,6 +232,98 @@ def psiphon_server_id_from_ip(ip):
     return server_id
 
 
+def normalize_lowercase_envelope(diagnostic_info) -> None:
+    '''
+    Modifies diagnostic_info from clients using the all-lowercase envelope
+    (Psiphon 4 feedback report v2 and later) to the key names the rest of the
+    pipeline dispatches on: `metadata` becomes `Metadata`, and `feedback`
+    becomes `Feedback` with its `message` renamed to `Message`. That leaves
+    `Feedback` mixed-case, holding `Message` beside a lowercase `email`.
+    Everything outside the envelope keeps the shape the client sent.
+    Must be called before is_diagnostic_info_sane, so it has to tolerate
+    arbitrary untrusted input. A block whose type is unexpected is left under
+    its original key rather than dropped, so that nothing the client sent is
+    lost before the report is stored.
+    '''
+
+    if not isinstance(diagnostic_info, dict):
+        return
+
+    if 'Metadata' in diagnostic_info or not isinstance(diagnostic_info.get('metadata'), dict):
+        return
+
+    diagnostic_info['Metadata'] = diagnostic_info.pop('metadata')
+
+    if isinstance(diagnostic_info.get('feedback'), dict):
+        feedback = diagnostic_info.pop('feedback')
+        if isinstance(feedback.get('message'), dict):
+            feedback['Message'] = feedback.pop('message')
+        diagnostic_info['Feedback'] = feedback
+
+
+def normalize_lowercase_envelope_test():
+    v2 = {
+        'metadata': {'appName': 'psiphon4', 'platform': 'ios', 'version': 2, 'id': 'A1B2C3D4E5F60718'},
+        'system': {'device': {'model': 'iPhone16,2'}, 'locale': 'en-CA'},
+        'app': {'appId': 'ca.psiphon.psiphon4', 'sponsorId': 'FFFFFFFFFFFFFFFF'},
+        'logs': [{'timestamp!!timestamp': '2026-09-02T10:00:00.000Z', 'category': 'tunnel-core'}],
+        'diagnostics': {'crashHistory': ['boom']},
+        'feedback': {'email': 'user@example.com', 'message': {'text': 'hello'}},
+    }
+    normalized = dict(v2)
+    normalize_lowercase_envelope(normalized)
+
+    assert(normalized['Metadata']['appName'] == 'psiphon4')
+    assert(normalized['Feedback']['email'] == 'user@example.com')
+    assert(normalized['Feedback']['Message']['text'] == 'hello')
+    assert('metadata' not in normalized and 'feedback' not in normalized)
+    assert('message' not in normalized['Feedback'])
+
+    assert(normalized['system']['device']['model'] == 'iPhone16,2')
+    assert(normalized['app']['sponsorId'] == 'FFFFFFFFFFFFFFFF')
+    assert(normalized['logs'][0]['category'] == 'tunnel-core')
+    assert(normalized['diagnostics']['crashHistory'] == ['boom'])
+
+    # Running it again must not disturb the result.
+    normalize_lowercase_envelope(normalized)
+    assert(normalized['Metadata']['appName'] == 'psiphon4')
+    assert(normalized['Feedback']['Message']['text'] == 'hello')
+
+    # A diagnostics-only report has a message object with no text.
+    no_text = {'metadata': {'id': 'A1B2C3D4E5F60718'}, 'feedback': {'message': {}}}
+    normalize_lowercase_envelope(no_text)
+    assert(no_text['Feedback']['Message'] == {})
+
+    no_feedback = {'metadata': {'id': 'A1B2C3D4E5F60718'}}
+    normalize_lowercase_envelope(no_feedback)
+    assert('Feedback' not in no_feedback)
+
+    legacy = {'Metadata': {'appName': 'psiphon'}, 'Feedback': {'Message': {'text': 'hi'}}}
+    legacy_copy = {'Metadata': {'appName': 'psiphon'}, 'Feedback': {'Message': {'text': 'hi'}}}
+    normalize_lowercase_envelope(legacy)
+    assert(legacy == legacy_copy)
+
+    # Non-dict and malformed input must not raise.
+    normalize_lowercase_envelope(None)
+    normalize_lowercase_envelope('nonsense')
+    normalize_lowercase_envelope({'metadata': 'nonsense'})
+
+    # An unexpected type keeps its original key, so the value is not dropped.
+    odd_feedback = {'metadata': {'id': 'A1B2C3D4E5F60718'}, 'feedback': 'nonsense'}
+    normalize_lowercase_envelope(odd_feedback)
+    assert(odd_feedback['feedback'] == 'nonsense')
+    assert('Feedback' not in odd_feedback)
+
+    odd_message = {'metadata': {'id': 'A1B2C3D4E5F60718'}, 'feedback': {'message': 'nonsense'}}
+    normalize_lowercase_envelope(odd_message)
+    assert(odd_message['Feedback']['message'] == 'nonsense')
+    assert('Message' not in odd_message['Feedback'])
+
+    print('normalize_lowercase_envelope test okay')
+
+normalize_lowercase_envelope.test = normalize_lowercase_envelope_test
+
+
 def is_diagnostic_info_sane(obj):
     '''
     Returns true if `obj` is a sane-looking diagnostic info object.
@@ -244,7 +338,7 @@ def is_diagnostic_info_sane(obj):
 
     exemplar = {
                 'Metadata': {
-                             'platform': lambda val: val in ['android', 'ios', 'ios-browser', 'ios-vpn', 'ios-vpn-on-mac', 'ios-app-on-mac', 'windows'],
+                             'platform': lambda val: val in ['android', 'ios', 'ios-browser', 'ios-vpn', 'ios-vpn-on-mac', 'ios-app-on-mac', 'macos', 'windows'],
                              'version': lambda val: val in range(1, 5),
                              'id': lambda val: re.match(r'^[a-fA-F0-9]{16}', str(val)) is not None
                              },
@@ -289,6 +383,14 @@ def is_diagnostic_info_sane_test():
     assert(not is_diagnostic_info_sane({'_id': 1, 'datetime': 1, 'Metadata': {'extra': 1, 'platform': 'windows', 'version': 1, 'id': 'AAAAAAAAAAAAAAAA'}}))
     assert(not is_diagnostic_info_sane({'Metadata': {'platform': 'badplatform', 'version': 1, 'id': 'AAAAAAAAAAAAAAAA'}}))
     assert(is_diagnostic_info_sane({'Metadata': {'_id': 1, 'platform': 'windows', 'version': 1, 'id': 'AAAAAAAAAAAAAAAA'}}))
+    assert(is_diagnostic_info_sane({'Metadata': {'platform': 'macos', 'version': 2, 'id': 'A1B2C3D4E5F60718'}}))
+
+    # A Psiphon 4 v2 report is only sane once its envelope has been normalized.
+    v2 = {'metadata': {'appName': 'psiphon4', 'platform': 'ios', 'version': 2, 'id': 'A1B2C3D4E5F60718'}}
+    assert(not is_diagnostic_info_sane(v2))
+    normalize_lowercase_envelope(v2)
+    assert(is_diagnostic_info_sane(v2))
+
     print('is_diagnostic_info_sane test okay')
 
 is_diagnostic_info_sane.test = is_diagnostic_info_sane_test

--- a/EmailResponder/FeedbackDecryptor/utils.py
+++ b/EmailResponder/FeedbackDecryptor/utils.py
@@ -191,6 +191,10 @@ def convert_psinet_values(config, obj):
 
         # Modern clients (Psiphon 4 feedback report v2) carry these under `app`
         # in camelCase; older clients use PsiphonInfo and SCREAMING_SNAKE.
+        # Both are allowed to be empty, and psinet has nothing to say about ''.
+        if not val:
+            continue
+
         if path[-1] in ('PROPAGATION_CHANNEL_ID', 'propagationChannelId'):
             prop_channel_name = prop_channel_id_to_name.get(val)
             if not prop_channel_name:
@@ -241,9 +245,9 @@ def normalize_lowercase_envelope(diagnostic_info) -> None:
     `Feedback` mixed-case, holding `Message` beside a lowercase `email`.
     Everything outside the envelope keeps the shape the client sent.
     Must be called before is_diagnostic_info_sane, so it has to tolerate
-    arbitrary untrusted input. A block whose type is unexpected is left under
-    its original key rather than dropped, so that nothing the client sent is
-    lost before the report is stored.
+    arbitrary untrusted input. A block whose type is unexpected, or whose
+    PascalCase name is already taken, is left under its original key rather
+    than dropped, so that nothing the client sent is lost before storage.
     '''
 
     if not isinstance(diagnostic_info, dict):
@@ -254,9 +258,9 @@ def normalize_lowercase_envelope(diagnostic_info) -> None:
 
     diagnostic_info['Metadata'] = diagnostic_info.pop('metadata')
 
-    if isinstance(diagnostic_info.get('feedback'), dict):
+    if isinstance(diagnostic_info.get('feedback'), dict) and 'Feedback' not in diagnostic_info:
         feedback = diagnostic_info.pop('feedback')
-        if isinstance(feedback.get('message'), dict):
+        if isinstance(feedback.get('message'), dict) and 'Message' not in feedback:
             feedback['Message'] = feedback.pop('message')
         diagnostic_info['Feedback'] = feedback
 
@@ -270,24 +274,24 @@ def normalize_lowercase_envelope_test():
         'diagnostics': {'crashHistory': ['boom']},
         'feedback': {'email': 'user@example.com', 'message': {'text': 'hello'}},
     }
-    normalized = dict(v2)
-    normalize_lowercase_envelope(normalized)
+    # Normalized in place, which is the documented contract.
+    normalize_lowercase_envelope(v2)
 
-    assert(normalized['Metadata']['appName'] == 'psiphon4')
-    assert(normalized['Feedback']['email'] == 'user@example.com')
-    assert(normalized['Feedback']['Message']['text'] == 'hello')
-    assert('metadata' not in normalized and 'feedback' not in normalized)
-    assert('message' not in normalized['Feedback'])
+    assert(v2['Metadata']['appName'] == 'psiphon4')
+    assert(v2['Feedback']['email'] == 'user@example.com')
+    assert(v2['Feedback']['Message']['text'] == 'hello')
+    assert('metadata' not in v2 and 'feedback' not in v2)
+    assert('message' not in v2['Feedback'])
 
-    assert(normalized['system']['device']['model'] == 'iPhone16,2')
-    assert(normalized['app']['sponsorId'] == 'FFFFFFFFFFFFFFFF')
-    assert(normalized['logs'][0]['category'] == 'tunnel-core')
-    assert(normalized['diagnostics']['crashHistory'] == ['boom'])
+    assert(v2['system']['device']['model'] == 'iPhone16,2')
+    assert(v2['app']['sponsorId'] == 'FFFFFFFFFFFFFFFF')
+    assert(v2['logs'][0]['category'] == 'tunnel-core')
+    assert(v2['diagnostics']['crashHistory'] == ['boom'])
 
     # Running it again must not disturb the result.
-    normalize_lowercase_envelope(normalized)
-    assert(normalized['Metadata']['appName'] == 'psiphon4')
-    assert(normalized['Feedback']['Message']['text'] == 'hello')
+    normalize_lowercase_envelope(v2)
+    assert(v2['Metadata']['appName'] == 'psiphon4')
+    assert(v2['Feedback']['Message']['text'] == 'hello')
 
     # A diagnostics-only report has a message object with no text.
     no_text = {'metadata': {'id': 'A1B2C3D4E5F60718'}, 'feedback': {'message': {}}}
@@ -318,6 +322,21 @@ def normalize_lowercase_envelope_test():
     normalize_lowercase_envelope(odd_message)
     assert(odd_message['Feedback']['message'] == 'nonsense')
     assert('Message' not in odd_message['Feedback'])
+
+    # Both spellings present: neither is overwritten by the other.
+    both_feedback = {'metadata': {'id': 'A1B2C3D4E5F60718'},
+                     'Feedback': {'Message': {'text': 'pascal'}},
+                     'feedback': {'message': {'text': 'lower'}}}
+    normalize_lowercase_envelope(both_feedback)
+    assert(both_feedback['Feedback']['Message']['text'] == 'pascal')
+    assert(both_feedback['feedback']['message']['text'] == 'lower')
+
+    both_message = {'metadata': {'id': 'A1B2C3D4E5F60718'},
+                    'feedback': {'Message': {'text': 'pascal'},
+                                 'message': {'text': 'lower'}}}
+    normalize_lowercase_envelope(both_message)
+    assert(both_message['Feedback']['Message']['text'] == 'pascal')
+    assert(both_message['Feedback']['message']['text'] == 'lower')
 
     print('normalize_lowercase_envelope test okay')
 


### PR DESCRIPTION
## Problem

Psiphon 4 now uploads feedback report schema v2 — an all-lowercase envelope (`metadata`, `system`, `app`, `logs`, `feedback`) with the user's text at `feedback.message.text`. Normative definition: [feedback-report-v2.schema.json](https://github.com/Psiphon-Inc/psiphon4-app/blob/main/schemas/feedback-report-v2.schema.json). The decryptor is hardcoded to the PascalCase envelope from the first key it touches, so `is_diagnostic_info_sane` rejects every v2 report. Since `_bucket_iterator` deletes the S3 object *before* processing, these aren't merely unrendered — they're destroyed.

## Approach

A thin adapter at ingress rather than a canonical model. Two keys are renamed on the way in — `metadata`→`Metadata`, `feedback`/`message`→`Feedback`/`Message` — because the pipeline dispatches, dedupes, indexes and translates on those names. Everything else passes through in the shape the client sent, and a new `template_psiphon4_2.mako` reads it directly. Version knowledge lives in one function and one template, with no branching between.

Also adds `macos` `propagationChannelId`/`sponsorId`, so sponsor and channel render as names rather than IDs.

Not addressed: Psiphon 4 still contributes nothing to the daily stats email, since `_get_stats_helper` filters on android/windows and reads `SystemInformation`. Pre-existing, and equally true of iOS.

## Two pre-existing crash paths, fixed here because this change routes more traffic into them

`datatransformer._translate_feedback` gated on a truthy `Message` dict then indexed `Message['text']` unconditionally. A message object carrying any other key raises `KeyError`, which `s3decryptor.py:270` catches, alerts on, and re-raises — killing the worker and losing in-flight reports whose S3 objects are already deleted. It also called Translate on a null or empty text, which is visible in production today as `[TRANSLATION_FAIL]` with the exception string stored as the language name. Now gated on `.get('text')`, matching `_should_email_data` and the template.

The `feedback id` log line in `s3decryptor` used chained `.get`, so a decrypted body that parsed to a list or string raised `AttributeError` one statement after the normalizer promises non-dict tolerance. Now uses `utils.coalesce`.

## Behaviour change

`_suppress_response` is now an allow-list — only `appName == 'psiphon'` collects an autoresponse, since `responses/` is Psiphon 3 copy. No shipping Psiphon 4 UI supplies `feedback.email` (`send_feedback.dart` passes only `userMessage`), so this hardens against a future one rather than stopping replies going out today. It is fail-closed, so **run `db.diagnostic_info.distinct('Metadata.appName')` before merging**: merge is deploy here, on an hourly `git pull` and restart.

## Testing

Two real uploads pulled off devices — iOS (103 log entries) and Android (1,266) — both validate against the v2 schema, both are rejected by `is_diagnostic_info_sane` on master and would be destroyed, and both pass the full chain here: every timestamp parsed (Android mixes 3- and 6-digit fractions), no dotted or `$`-pref

Legacy paths confirmed: ryve v2 renders unchanged, template dispatch resolves identically for all eight Psiphon 3 combinations, and the `utils`, `redactor`, `mailformatter` and `autoresponder` suites pass.
